### PR TITLE
TST tests for image resampling

### DIFF
--- a/pizza_cutter/des_pizza_cutter/_se_image.py
+++ b/pizza_cutter/des_pizza_cutter/_se_image.py
@@ -77,6 +77,9 @@ class SEImageSlice(object):
     set_psf(ra, dec)
         Set the PSF of the slice using the input (ra, dec). Sets the `psf`,
         `psf_x_start`, `psf_y_start` and `psf_box_size` attributes.
+    resample(wcs, wcs_position_offset, x_start, y_start, box_size,
+             psf_x_start, psf_y_start, psf_box_size)
+        Resample a SEImageSlice to a new WCS.
 
     Attributes
     ----------

--- a/pizza_cutter/des_pizza_cutter/tests/test_se_image_resample.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_se_image_resample.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pytest
 
+import galsim
 import piff
 
 from .._se_image import SEImageSlice
@@ -42,16 +43,119 @@ def test_se_image_resample_smoke(se_image_data, coadd_image_data):
             assert np.all(np.isfinite(resampled_data[k])), k
 
 
-# @pytest.mark.parametrize('eps_x', [
-#     -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75])
-# @pytest.mark.parametrize('eps_y', [
-#     -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75])
-# def test_se_image_resample_shifts(se_image_data, eps_x, eps_y):
-#
-#     def _sky2image(ra, dec):
-#         return ra, dec + eps_y
-#
-#     def _image2sky(x, y):
-#         return x + eps_x, y
-#
-#     assert False
+@pytest.mark.parametrize('eps_x', [-3, 0, 3])
+@pytest.mark.parametrize('eps_y', [-5, 0, 5])
+def test_se_image_resample_shifts(se_image_data, eps_x, eps_y):
+
+    # SE WCS defs
+    # starts at x_start, y_start in image coords
+    # applies eps_y to shift where in the underlying image
+    # the interp is done
+    x_start = 10
+    y_start = 20
+
+    def _se_sky2image(ra, dec):
+        return ra + x_start, dec + y_start
+
+    def _se_image2sky(x, y):
+        # SE image location of (x_start, y_start) should map to
+        # (0, 0) in the sky
+        return x - x_start, y - y_start
+
+    # coadd WCS defs
+    # starts at (coadd_x_start, coadd_y_start) in image coords
+    # applies eps_x to shift location in underlying image
+    # has a position offset of 4
+    pos_off = 4
+    coadd_x_start = 600
+    coadd_y_start = 700
+
+    class FakeWCS(object):
+        def image2sky(self, x, y):
+            # coadd position of
+            # (coadd_x_start + pos_off, coadd_y_start + pos_off) should map to
+            # (0, 0) in the sky
+            return (
+                x - pos_off - coadd_x_start,
+                y - pos_off - coadd_y_start)
+
+        def sky2image(self, longitude, latitude):
+            return (
+                longitude + pos_off + coadd_x_start,
+                latitude + pos_off + coadd_y_start)
+
+    se_im = SEImageSlice(
+        source_info=se_image_data['source_info'],
+        psf_model=galsim.Gaussian(fwhm=0.8),
+        wcs=se_image_data['eu_wcs'], noise_seed=10)
+
+    # we are going to override these methods for testing
+    se_im.sky2image = _se_sky2image
+    se_im.image2sky = _se_image2sky
+
+    # now make it seem as if the image data has been read in
+    # by setting it too
+    rng = np.random.RandomState(seed=42)
+    se_im.image = rng.normal(size=(600, 600)) + 100
+    se_im.weight = rng.normal(size=(600, 600)) + 100
+    se_im.noise = rng.normal(size=(600, 600)) + 100
+    se_im.bmask = (rng.normal(size=(600, 600)) * 100).astype(np.int32)
+    se_im.x_start = x_start
+    se_im.y_start = y_start
+    se_im.box_size = 600
+
+    # fake the PSF
+    se_im.psf = rng.normal(size=(55, 55)) + 100
+    se_im.psf_box_size = 55
+    se_im.psf_x_start = x_start + 300 - 27
+    se_im.psf_y_start = y_start + 300 - 27
+
+    # the inputs here are zero-indexed, thus they lack pos_off
+    # we apply the shifts eps_x, eps_y to test moving the coadd around
+    # relative to the SE image to make sure we are getting the right pixels
+    # psf is close to centered around the middle of the 100x100 picel patch
+    resampled_data = se_im.resample(
+        wcs=FakeWCS(),
+        wcs_position_offset=pos_off,
+        x_start=coadd_x_start + 250 + eps_x,
+        y_start=coadd_y_start + 250 + eps_y,
+        box_size=100,
+        psf_x_start=coadd_x_start + 300 - 11 + eps_x,
+        psf_y_start=coadd_y_start + 300 - 11 + eps_y,
+        psf_box_size=23)
+
+    # first check they are finite
+    for k in resampled_data:
+        if k != 'bmask' and k != 'ormask':
+            assert np.all(np.isfinite(resampled_data[k])), k
+
+    # now check the values
+    # whole pixel shifts interpolate exactly, up to numerical errors
+    # for eps_x, eps_y = (0, 0), the coadd is located in the central 100 x 100
+    # pixels of the SE image
+    wcs = FakeWCS()
+    ra, dec = wcs.image2sky(
+        # using pos_off here since calling directly!
+        coadd_x_start + pos_off + 250 + eps_x,
+        coadd_y_start + pos_off + 250 + eps_y)
+    final_x_start, final_y_start = _se_sky2image(ra, dec)
+    final_x_start -= x_start
+    final_y_start -= y_start
+    for k in ['image', 'noise', 'weight', 'bmask']:
+        assert np.allclose(
+            resampled_data[k],
+            getattr(se_im, k)[final_y_start:final_y_start+100,
+                              final_x_start:final_x_start+100]), k
+
+    ra, dec = wcs.image2sky(
+        # using pos_off here since calling directly!
+        # need extra offset for the PSF stamp
+        coadd_x_start + pos_off + 300 - 11 + eps_x,
+        coadd_y_start + pos_off + 300 - 11 + eps_y)
+    final_x_start, final_y_start = _se_sky2image(ra, dec)
+    final_x_start -= (x_start + 300 - 27)
+    final_y_start -= (y_start + 300 - 27)
+    assert np.allclose(
+        resampled_data['psf'],
+        se_im.psf[final_y_start:final_y_start+23,
+                  final_x_start:final_x_start+23]), k


### PR DESCRIPTION
The tests here make sure that the code runs with a real WCS and that with simple WCS functions it is resampling properly at integer pixel locations as things are shifted around.

Closes #46 