### PR TITLE
BUG fix divide by zero in making noise fields

### DIFF
--- a/pizza_cutter/des_pizza_cutter/_se_image.py
+++ b/pizza_cutter/des_pizza_cutter/_se_image.py
@@ -37,8 +37,13 @@ def _read_image(path, ext):
 def _get_noise_image(weight_path, weight_ext, scale, noise_seed):
     """Cached generation of memory mapped noise images."""
     wgt = _read_image(weight_path, ext=weight_ext)
+    zwgt_msk = wgt <= 0.0
+    med_wgt = np.median(wgt[~zwgt_msk])
+
     return MemMappedNoiseImage(
-        seed=noise_seed, weight=wgt / scale**2, sx=1024, sy=1024)
+        seed=noise_seed,
+        weight=(wgt * (~zwgt_msk) + zwgt_msk * med_wgt) / scale**2,
+        sx=1024, sy=1024)
 
 
 @functools.lru_cache(maxsize=8)

--- a/pizza_cutter/des_pizza_cutter/tests/test_se_image_slice_io.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_se_image_slice_io.py
@@ -51,9 +51,10 @@ def test_se_image_slice_read(monkeypatch, se_image_data):
         ext=se_image_data['source_info']['bmask_ext'])
     assert np.array_equal(bmask[50:82, 10:42], se_im.bmask)
 
+    zmsk = wgt <= 0
     nse = MemMappedNoiseImage(
         seed=10,
-        weight=wgt,
+        weight=wgt * (~zmsk) + zmsk * np.median(wgt[~zmsk]),
         sx=1024,
         sy=1024)
     assert np.array_equal(nse[50:82, 10:42], se_im.noise)


### PR DESCRIPTION
This PR fixes the divide by zero for the full SE image weight maps. I interpolate the median weight before dividing.