### PR TITLE
ENH enable galsim psfs

### DIFF
--- a/pizza_cutter/des_pizza_cutter/_load_info.py
+++ b/pizza_cutter/des_pizza_cutter/_load_info.py
@@ -127,14 +127,7 @@ def _munge_fits_header(hdr):
 
 
 def _build_gsobject(config):
-    eval_locals = locals()
     dct = copy.deepcopy(config)
-    # hacking in some galsim eval stuff here...
-    for k in dct:
-        if k == 'type':
-            continue
-        elif isinstance(dct[k], str) and dct[k][0] == '$':
-            dct[k] = eval(dct[k][1:], globals(), eval_locals)
     _psf, safe = galsim.config.BuildGSObject({'blah': dct}, 'blah')
     assert safe, (
         "You must provide a reusable PSF object for galsim object PSFs")

--- a/pizza_cutter/des_pizza_cutter/tests/test_build_gsobject.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_build_gsobject.py
@@ -1,0 +1,19 @@
+import galsim.config
+
+from .._load_info import _build_gsobject
+
+
+def test_build_gsobject_psf_dict():
+    psf_dict = {'type': 'Gaussian', 'fwhm': 0.9}
+    psf = _build_gsobject(psf_dict)
+    assert isinstance(psf, galsim.Gaussian)
+    assert psf.fwhm == 0.9
+
+
+def test_build_gsobject_psf_dict_eval():
+    psf_dict = {
+        'type': 'Gaussian',
+        'fwhm': '$0.9 + 0.5'}
+    psf = _build_gsobject(psf_dict)
+    assert isinstance(psf, galsim.Gaussian)
+    assert psf.fwhm == 1.4

--- a/pizza_cutter/des_pizza_cutter/tests/test_build_gsobject.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_build_gsobject.py
@@ -8,12 +8,3 @@ def test_build_gsobject_psf_dict():
     psf = _build_gsobject(psf_dict)
     assert isinstance(psf, galsim.Gaussian)
     assert psf.fwhm == 0.9
-
-
-def test_build_gsobject_psf_dict_eval():
-    psf_dict = {
-        'type': 'Gaussian',
-        'fwhm': '$0.9 + 0.5'}
-    psf = _build_gsobject(psf_dict)
-    assert isinstance(psf, galsim.Gaussian)
-    assert psf.fwhm == 1.4


### PR DESCRIPTION
This PR allows us to specify a galsim psf model to be used in the info file. We will need this for simulations and some end to end testing.