### PR TITLE
ENH add env vars to metadata, better handle others

### DIFF
--- a/pizza_cutter/des_pizza_cutter/_des_info.py
+++ b/pizza_cutter/des_pizza_cutter/_des_info.py
@@ -78,12 +78,12 @@ def add_extra_des_coadd_tile_info(*, info, piff_run):
     # always true for the coadd
     info['magzp'] = MAGZP_REF
     info['scale'] = 1.0
-    info['image_shape'] = 10000, 10000
+    info['image_shape'] = [10000, 10000]
 
     info['image_flags'] = 0  # TODO set this properly for the coadd?
 
     for index, ii in enumerate(info['src_info']):
-        ii['image_shape'] = 4096, 2048
+        ii['image_shape'] = [4096, 2048]
         ii['image_flags'] = 0
 
         ii['image_ext'] = 'sci'
@@ -109,7 +109,8 @@ def add_extra_des_coadd_tile_info(*, info, piff_run):
                 piff_run=piff_run,
             )
 
-            ii['piff_path'] = piff_data['psf_path']
+            if piff_data['psf_path'] is not None:
+                ii['piff_path'] = piff_data['psf_path']
             ii['image_flags'] |= piff_data['flags']
 
         # image scale

--- a/pizza_cutter/des_pizza_cutter/_load_info.py
+++ b/pizza_cutter/des_pizza_cutter/_load_info.py
@@ -44,12 +44,19 @@ def load_objects_into_info(*, info):
             'image_path' : the path to the FITS file with the SE image
             'image_ext' : the name of the FITS extension with the SE image
 
+        The info structure can optionally have the key
+
+            'affine_wcs_config' : a dictionary used to build an `AffineWCS`
+                instance
+
         The source info structures can optionally have the keys
 
             'psfex_path' : the path to the PSFEx PSF model
             'piff_path' : the path to the Piff PSF model
             'galsim_psf_config' : a dictionary with a valid galsim config
                 file entry to build the PSF as a galsim object.
+            'affine_wcs_config' : a dictionary used to build an `AffineWCS`
+                instance
     """
     try:
         info['image_wcs'] = eu.wcsutil.WCS(

--- a/pizza_cutter/des_pizza_cutter/_piff_tools.py
+++ b/pizza_cutter/des_pizza_cutter/_piff_tools.py
@@ -4,7 +4,9 @@ import logging
 import numpy as np
 import piff
 import fitsio
+
 from ._constants import PIFF_PSF_IN_BLACKLIST
+from ..files import expandpath
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +81,7 @@ def get_piff_psf(psf_path):
 @lru_cache(maxsize=128)
 def _get_info(info_path):
     """read the info extension of the summary file"""
-    if not os.path.exists(info_path):
+    if not os.path.exists(expandpath(info_path)):
         raise RuntimeError('missing piff info file: %s' % info_path)
 
     return fitsio.read(info_path, ext='info')
@@ -99,8 +101,6 @@ def _extract_expnum_and_ccdnum(image_path):
 def _get_paths_from_image_path(image_path, piff_run):
     """Get the piff and info path from the image path.
 
-    NOTE: Requires PIFF_DATA_DIR environment variable to be set!
-
     Parameters
     ----------
     image_path : str
@@ -112,14 +112,12 @@ def _get_paths_from_image_path(image_path, piff_run):
     -------
     A dict with keys info_path and psf_path
     """
-    PIFF_DATA_DIR = os.environ['PIFF_DATA_DIR']
-
     img_bname = os.path.basename(image_path)
     piff_bname = img_bname.replace('immasked.fits.fz', 'piff.fits')
     expnum = int(piff_bname.split('_')[0][1:])
 
     exp_dir = os.path.join(
-        PIFF_DATA_DIR,
+        '$PIFF_DATA_DIR',
         piff_run,
         str(expnum),
     )

--- a/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
+++ b/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
@@ -595,7 +595,9 @@ def _build_metadata(*, config):
         ('desmeds_version', 'S%d' % len(desmeds_version)),
         ('meds_version', 'S%d' % len(meds_version)),
         ('meds_fmt_version', 'S%d' % len(MEDS_FMT_VERSION)),
-        ('meds_dir', 'S%d' % len(os.environ['MEDS_DIR']))]
+        ('meds_dir', 'S%d' % len(os.environ['MEDS_DIR'])),
+        ('piff_data_dir', 'S%d' % len(os.environ.get('PIFF_DATA_DIR', ' '))),
+        ('desdata', 'S%d' % len(os.environ.get('DESDATA', ' ')))]
     metadata = np.zeros(1, dt)
     metadata['magzp_ref'] = MAGZP_REF
     metadata['config'] = config
@@ -609,4 +611,6 @@ def _build_metadata(*, config):
     metadata['meds_fmt_version'] = MEDS_FMT_VERSION
     metadata['pizza_cutter_version'] = __version__
     metadata['meds_dir'] = os.environ['MEDS_DIR']
+    metadata['piff_data_dir'] = os.environ.get('PIFF_DATA_DIR', '')
+    metadata['desdata'] = os.environ.get('DESDATA', '')
     return metadata

--- a/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_metadata.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_metadata.py
@@ -16,6 +16,8 @@ from ..._version import __version__
 
 def test_pizza_cutter_build_metadata(monkeypatch):
     monkeypatch.setenv('MEDS_DIR', 'BLAH')
+    monkeypatch.setenv('PIFF_DATA_DIR', 'BLAHH')
+    monkeypatch.setenv('DESDATA', 'BLAHHH')
     config = 'blah blah blah'
 
     metadata = _build_metadata(config=config)
@@ -38,3 +40,8 @@ def test_pizza_cutter_build_metadata(monkeypatch):
         metadata['meds_fmt_version'] == MEDS_FMT_VERSION.encode('ascii'))
     assert np.all(
         metadata['meds_dir'] == os.environ['MEDS_DIR'].encode('ascii'))
+    assert np.all(
+        metadata['piff_data_dir'] ==
+        os.environ['PIFF_DATA_DIR'].encode('ascii'))
+    assert np.all(
+        metadata['desdata'] == os.environ['DESDATA'].encode('ascii'))


### PR DESCRIPTION
This PR adds some other env vars to the metadata and makes sure to handle the PIFF_DATA_DIR correctly. 

Closes #113 