### PR TITLE
reduce max box size in example metadetect

### DIFF
--- a/config_files/metadetect.yaml
+++ b/config_files/metadetect.yaml
@@ -43,7 +43,7 @@ bmask_flags: 1073741824  # 2**30
 meds:
   box_padding: 2
   box_type: iso_radius
-  max_box_size: 256
+  max_box_size: 32
   min_box_size: 32
   rad_fac: 2
   rad_min: 4


### PR DESCRIPTION
closes #124 

We are using simple moments with a small weight function, no need for
the larger box sizes

20x20 would probably be good enough, round to 32 to make the FFTs
happy

