### PR TITLE
enable global temp dir

### DIFF
--- a/bin/des-pizza-cutter
+++ b/bin/des-pizza-cutter
@@ -2,11 +2,55 @@
 import os
 import sys
 import logging
+import tempfile
 
 import click
 import yaml
 from pizza_cutter.des_pizza_cutter import (
     make_des_pizza_slices, load_objects_into_info)
+
+def go(config, info, tag, output_path, log_level, seed, tmpdir):
+    """Create a metadetection MEDS file from a DES coadd tile."""
+
+    logging.basicConfig(stream=sys.stdout)
+    logging.getLogger('pizza_cutter').setLevel(
+        getattr(logging, log_level.upper()))
+
+    with open(config, 'r') as fp:
+        _config = fp.read()
+    cfg = yaml.load(_config, Loader=yaml.Loader)
+
+    with open(info, 'r') as fp:
+        info = yaml.load(fp, Loader=yaml.Loader)
+
+    print('tilename:', info['tilename'], flush=True)
+    print('band:', info['band'], flush=True)
+
+    # this loads all of the data we need into the info dict
+    print('loading PSF and WCS data...', flush=True)
+    load_objects_into_info(info=info)
+
+    sname = os.path.basename(config).replace('.yaml', '')
+    if tag is not None:
+        sname = '-'.join([sname, tag])
+    meds_path = os.path.join(
+        output_path,
+        "%s_%s_%s_meds-pizza-slices.fits" % (
+            info['tilename'],
+            info['band'],
+            sname))
+    print('output meds file:', meds_path, flush=True)
+
+    print('making pizza slices!', flush=True)
+    make_des_pizza_slices(
+        tmpdir=tmpdir,
+        config=_config,
+        meds_path=meds_path,
+        info=info,
+        fpack_pars=cfg.get('fpack_pars', None),
+        seed=seed,
+        coadd_config=cfg['coadd'],
+        single_epoch_config=cfg['single_epoch'])
 
 
 @click.command()
@@ -42,46 +86,15 @@ def main(
         use_tmpdir):
     """Create a metadetection MEDS file from a DES coadd tile."""
 
-    logging.basicConfig(stream=sys.stdout)
-    logging.getLogger('pizza_cutter').setLevel(
-        getattr(logging, log_level.upper()))
+    def _call(tmpdir):
+        go(config, info, tag, output_path, log_level, seed, tmpdir)
 
-    with open(config, 'r') as fp:
-        _config = fp.read()
-    cfg = yaml.load(_config, Loader=yaml.Loader)
-
-    with open(info, 'r') as fp:
-        info = yaml.load(fp, Loader=yaml.Loader)
-
-    print('tilename:', info['tilename'], flush=True)
-    print('band:', info['band'], flush=True)
-
-    # this loads all of the data we need into the info dict
-    print('loading PSF and WCS data...', flush=True)
-    load_objects_into_info(info=info)
-
-    sname = os.path.basename(config).replace('.yaml', '')
-    if tag is not None:
-        sname = '-'.join([sname, tag])
-    meds_path = os.path.join(
-        output_path,
-        "%s_%s_%s_meds-pizza-slices.fits" % (
-            info['tilename'],
-            info['band'],
-            sname))
-    print('output meds file:', meds_path, flush=True)
-
-    print('making pizza slices!', flush=True)
-    make_des_pizza_slices(
-        use_tmpdir=use_tmpdir,
-        config=_config,
-        meds_path=meds_path,
-        info=info,
-        fpack_pars=cfg.get('fpack_pars', None),
-        seed=seed,
-        coadd_config=cfg['coadd'],
-        single_epoch_config=cfg['single_epoch'])
-
+    if use_tmpdir:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _call(tmpdir)
+    else:
+        tmpdir = None
+        _call(tmpdir)
 
 if __name__ == '__main__':
     main()

--- a/bin/des-pizza-cutter
+++ b/bin/des-pizza-cutter
@@ -9,6 +9,7 @@ import yaml
 from pizza_cutter.des_pizza_cutter import (
     make_des_pizza_slices, load_objects_into_info)
 
+
 def go(config, info, tag, output_path, log_level, seed, tmpdir):
     """Create a metadetection MEDS file from a DES coadd tile."""
 
@@ -80,21 +81,33 @@ def go(config, info, tag, output_path, log_level, seed, tmpdir):
     required=True)
 @click.option(
     '--use-tmpdir', is_flag=True,
-    help='use a temporary directory to stage data')
+    help=(
+        'use a temporary directory to stage data. set --tmpdir to specify the '
+        'name of the temporary directory, otherwise one will be created'))
+@click.option(
+    '--tmpdir', type=str, default=None,
+    help=(
+        'the name of the temporary directory to use. if passed without '
+        '--use-tmpdir, it will still be used.'))
 def main(
         config, info, tag, output_path, log_level, seed,
-        use_tmpdir):
+        use_tmpdir, tmpdir):
     """Create a metadetection MEDS file from a DES coadd tile."""
 
-    def _call(tmpdir):
-        go(config, info, tag, output_path, log_level, seed, tmpdir)
+    def _call(_tmpdir):
+        go(config, info, tag, output_path, log_level, seed, _tmpdir)
 
-    if use_tmpdir:
-        with tempfile.TemporaryDirectory() as tmpdir:
+    if use_tmpdir and tmpdir is None:
+        tmpdir = tempfile.TemporaryDirectory().name
+
+    if tmpdir is not None:
+        try:
             _call(tmpdir)
+        finally:
+            os.system("rm -rf %s" % os.path.join(tmpdir, "*"))
     else:
-        tmpdir = None
         _call(tmpdir)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/run-metadetect-on-coadd-sim
+++ b/bin/run-metadetect-on-coadd-sim
@@ -25,7 +25,7 @@ def _make_masking_func(coadd_config):
 
     if 'masking_config' in cfg:
         cfg = cfg['masking_config']
-        
+
         assert False, "Double check that this pickles OK"
         mfunc = functools.partial(
             interpolate_ngmix_multiband_obs,
@@ -37,7 +37,7 @@ def _make_masking_func(coadd_config):
         return None
 
 
-def _build_meds_list(*, tilename, band, sim_path, coadd_config, seed):
+def _build_meds_list(*, tilename, band, sim_path, coadd_config, seed, tmpdir):
     with open(coadd_config, 'r') as fp:
         _config = fp.read()
 
@@ -75,6 +75,7 @@ def _build_meds_list(*, tilename, band, sim_path, coadd_config, seed):
             tmpdir=tmpdir,
         )
     return mlist
+
 
 def go(metadetect_config, coadd_config, output_path, sim_path,
        tilename, band, tag, seed, log_level, part, tmpdir):
@@ -164,21 +165,31 @@ def go(metadetect_config, coadd_config, output_path, sim_path,
 @click.option(
     '--use-tmpdir', is_flag=True,
     help='use a temporary directory to stage data')
+@click.option(
+    '--tmpdir', type=str, default=None,
+    help=(
+        'the name of the temporary directory to use. if passed without '
+        '--use-tmpdir, it will still be used.'))
 def main(
         metadetect_config, coadd_config, output_path, sim_path,
-        tilename, band, tag, seed, log_level, part, use_tmpdir):
+        tilename, band, tag, seed, log_level, part, use_tmpdir, tmpdir):
     """Run metdetect on MEDS_FILES."""
 
     def _call(tmpdir):
         go(metadetect_config, coadd_config, output_path, sim_path,
            tilename, band, tag, seed, log_level, part, tmpdir)
 
-    if use_tmpdir:
-        with tempfile.TemporaryDirectory() as tmpdir:
+    if use_tmpdir and tmpdir is None:
+        tmpdir = tempfile.TemporaryDirectory().name
+
+    if tmpdir is not None:
+        try:
             _call(tmpdir)
+        finally:
+            os.system("rm -rf %s" % os.path.join(tmpdir, "*"))
     else:
-        tmpdir=None
         _call(tmpdir)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/run-metadetect-on-coadd-sim
+++ b/bin/run-metadetect-on-coadd-sim
@@ -70,8 +70,55 @@ def _build_meds_list(*, tilename, band, sim_path, coadd_config, seed):
                     os.path.join(sim_path, cfg['psf'])
                     if isinstance(cfg['psf'], str)
                     else cfg['psf']),
-                seed=seed + i))
+                seed=seed + i),
+            tmpdir=tmpdir,
+        )
     return mlist
+
+def go(metadetect_config, coadd_config, output_path, sim_path,
+       tilename, band, tag, seed, log_level, part, tmpdir):
+
+    with open(metadetect_config, 'r') as fp:
+        _metadetect_config = yaml.load(fp.read())
+
+    logging.basicConfig(
+        stream=sys.stdout, level=getattr(logging, log_level.upper()))
+
+    part, n_parts = part.split(':')
+    part = int(part)
+    n_parts = int(n_parts)
+
+    sname = os.path.basename(coadd_config).replace('.yaml', '')
+    if tag is not None:
+        sname = '-'.join([sname, tag])
+    filename = os.path.join(
+        output_path,
+        "%s_%s_meds-pizza-slices-metadetect-output-part%04d.fits" % (
+            tilename, sname, part))
+
+    mlist = _build_meds_list(
+        tilename=tilename,
+        band=band,
+        sim_path=sim_path,
+        coadd_config=coadd_config,
+        seed=seed,
+        tmpdir=tmpdir,
+    )
+    mbmeds = MultiBandNGMixMEDS(mlist)
+
+    def _call(fname):
+        run_metadetect(
+            config=_metadetect_config,
+            output_file=fname,
+            multiband_meds=mbmeds,
+            seed=seed,
+            part=part,
+            n_parts=n_parts,
+            preprocessing_function=_make_masking_func(coadd_config))
+
+    # this works even if tmpdir is None
+    with StagedOutFile(filename, tmpdir=tmpdir) as sf:
+        _call(sf.path)
 
 
 @click.command()
@@ -120,49 +167,17 @@ def main(
         metadetect_config, coadd_config, output_path, sim_path,
         tilename, band, tag, seed, log_level, part, use_tmpdir):
     """Run metdetect on MEDS_FILES."""
-    with open(metadetect_config, 'r') as fp:
-        _metadetect_config = yaml.load(fp.read())
 
-    logging.basicConfig(
-        stream=sys.stdout, level=getattr(logging, log_level.upper()))
-
-    part, n_parts = part.split(':')
-    part = int(part)
-    n_parts = int(n_parts)
-
-    sname = os.path.basename(coadd_config).replace('.yaml', '')
-    if tag is not None:
-        sname = '-'.join([sname, tag])
-    filename = os.path.join(
-        output_path,
-        "%s_%s_meds-pizza-slices-metadetect-output-part%04d.fits" % (
-            tilename, sname, part))
-
-    mlist = _build_meds_list(
-        tilename=tilename,
-        band=band,
-        sim_path=sim_path,
-        coadd_config=coadd_config,
-        seed=seed)
-    mbmeds = MultiBandNGMixMEDS(mlist)
-
-    def _call(fname):
-        run_metadetect(
-            config=_metadetect_config,
-            output_file=fname,
-            multiband_meds=mbmeds,
-            seed=seed,
-            part=part,
-            n_parts=n_parts,
-            preprocessing_function=_make_masking_func(coadd_config))
+    def _call(tmpdir):
+        go(metadetect_config, coadd_config, output_path, sim_path,
+           tilename, band, tag, seed, log_level, part, tmpdir)
 
     if use_tmpdir:
         with tempfile.TemporaryDirectory() as tmpdir:
-            with StagedOutFile(filename, tmpdir) as sf:
-                _call(sf.path)
+            _call(tmpdir)
     else:
-        _call(filename)
-
+        tmpdir=None
+        _call(tmpdir)
 
 if __name__ == '__main__':
     main()

--- a/bin/run-metadetect-on-slices
+++ b/bin/run-metadetect-on-slices
@@ -5,6 +5,7 @@ run metadetect on a slice file
 import sys
 import logging
 import tempfile
+import os
 
 import click
 import yaml
@@ -121,16 +122,21 @@ def _process(*,
 @click.option(
     '--log-level', default='warning', type=str,
     help='python logging level')
+@click.option(
+    '--tmpdir', type=str, default=None,
+    help=(
+        'the name of the temporary directory to use. if passed without '
+        '--use-tmpdir, it will still be used.'))
 def main(
         meds_files, config, output_path, seed, use_tmpdir, part, log_level,
-        meds_range):
+        meds_range, tmpdir):
     """Run metdetect on MEDS_FILES."""
 
     if part is not None and meds_range is not None:
         raise click.BadParameter(
             'You must specify only one of `--part` and `--range`')
 
-    def _call_process(*, tmpdir):
+    def _call(tmpdir):
         _process(
             meds_files=meds_files,
             config=config,
@@ -142,11 +148,16 @@ def main(
             tmpdir=tmpdir,
            )
 
-    if use_tmpdir:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            _call_process(tmpdir=tmpdir)
+    if use_tmpdir and tmpdir is None:
+        tmpdir = tempfile.TemporaryDirectory().name
+
+    if tmpdir is not None:
+        try:
+            _call(tmpdir)
+        finally:
+            os.system("rm -rf %s" % os.path.join(tmpdir, "*"))
     else:
-        _call_process(tmpdir=None)
+        _call(tmpdir)
 
 
 if __name__ == '__main__':

--- a/pizza_cutter/coadd_sim_slicer/medsreader.py
+++ b/pizza_cutter/coadd_sim_slicer/medsreader.py
@@ -78,12 +78,14 @@ class CoaddSimSliceMEDS(NGMixMEDS):
         The random seed used to make the noise field.
     noise_size : int, optional
         The size of patches for generating the noise image.
+    tmpdir: string, optional
+        Optional temporary directory for temp files
     """
     def __init__(
             self, *, central_size, buffer_size, image_path, image_ext,
             bkg_path=None, bkg_ext=None, seg_path=None, seg_ext=None,
             weight_path, weight_ext, bmask_path, bmask_ext, psf, seed,
-            noise_size=1000):
+            noise_size=1000, tmpdir=None):
 
         # we need to set the slice properties here
         # they get used later to subset the images
@@ -155,7 +157,9 @@ class CoaddSimSliceMEDS(NGMixMEDS):
             seed=seed,
             weight=self._fits_objs['weight'][self._weight_ext],
             fill_weight=max_wgt,
-            sx=noise_size, sy=noise_size)
+            sx=noise_size, sy=noise_size,
+            dir=tmpdir,
+        )
 
         # set metadata just in case
         self._meta = np.zeros(1, dtype=[('magzp_ref', 'f8')])

--- a/pizza_cutter/des_pizza_cutter/_coadd_slices.py
+++ b/pizza_cutter/des_pizza_cutter/_coadd_slices.py
@@ -57,7 +57,8 @@ def _build_slice_inputs(
         mask_tape_bumps,
         edge_buffer,
         wcs_type,
-        psf_type):
+        psf_type,
+        tmpdir=None):
     """Build the inputs to coadd a single slice.
 
     Parameters
@@ -85,6 +86,8 @@ def _build_slice_inputs(
         'noise' - use the maximum of the weight map for each SE image.
         'noise-fwhm' - use the maximum of the weight map divided by the
             (PSF FWHM)**4
+    tmpdir: optional, string
+        Optional temporary directory for temporary files
 
     These next options are from the 'single_epoch' section of the main
     configuration file (passed around as `single_epoch_config` in the code).
@@ -164,6 +167,7 @@ def _build_slice_inputs(
                 wcs_position_offset=se_info['position_offset'],
                 noise_seed=se_info['noise_seed'],
                 mask_tape_bumps=mask_tape_bumps,
+                tmpdir=tmpdir,
             )
 
             # first try a very rough cut on the patch center

--- a/pizza_cutter/des_pizza_cutter/_se_image.py
+++ b/pizza_cutter/des_pizza_cutter/_se_image.py
@@ -53,7 +53,7 @@ def _read_image(path, ext):
 
 
 @functools.lru_cache(maxsize=32)
-def _get_noise_image(weight_path, weight_ext, scale, noise_seed):
+def _get_noise_image(weight_path, weight_ext, scale, noise_seed, tmpdir):
     """Cached generation of memory mapped noise images."""
     wgt = _read_image(weight_path, ext=weight_ext)
     zwgt_msk = wgt <= 0.0
@@ -62,7 +62,9 @@ def _get_noise_image(weight_path, weight_ext, scale, noise_seed):
     return MemMappedNoiseImage(
         seed=noise_seed,
         weight=(wgt * (~zwgt_msk) + zwgt_msk * max_wgt) / scale**2,
-        sx=1024, sy=1024)
+        dir=tmpdir,
+        sx=1024, sy=1024,
+    )
 
 
 @functools.lru_cache(maxsize=32)
@@ -139,6 +141,8 @@ class SEImageSlice(object):
     mask_tape_bumps: boold
         If True, turn on TAPEBUMP flag and turn off SUSPECT in bmask for
         tape bump regions in DES CCDs.
+    tmpdir: optional, string
+        Optional temporary directory for temporary files
 
     Methods
     -------
@@ -211,7 +215,8 @@ class SEImageSlice(object):
                  wcs,
                  wcs_position_offset,
                  noise_seed,
-                 mask_tape_bumps):
+                 mask_tape_bumps,
+                 tmpdir=None):
 
         self.source_info = source_info
         self._psf_model = psf_model
@@ -219,6 +224,7 @@ class SEImageSlice(object):
         self._wcs_position_offset = wcs_position_offset
         self._noise_seed = noise_seed
         self._mask_tape_bumps = mask_tape_bumps
+        self._tmpdir = tmpdir
 
         # get the image shape
         if 'image_shape' in source_info:
@@ -304,7 +310,9 @@ class SEImageSlice(object):
         # we are using the weight path and extension as part of the cache key
         nse = _get_noise_image(
             self.source_info['weight_path'], self.source_info['weight_ext'],
-            scale, self._noise_seed)
+            scale, self._noise_seed,
+            self._tmpdir,
+        )
         self.noise = nse[
             y_start:y_start+box_size, x_start:x_start+box_size].copy()
 

--- a/pizza_cutter/des_pizza_cutter/tests/conftest.py
+++ b/pizza_cutter/des_pizza_cutter/tests/conftest.py
@@ -103,7 +103,9 @@ def se_image_data():
             source_info['image_path'],
             ext=source_info['image_ext'])
         se_wcs_data = {
-            k.lower(): _se_wcs_data[k] for k in _se_wcs_data.keys() if k is not None}
+            k.lower(): _se_wcs_data[k] for k in _se_wcs_data.keys()
+            if k is not None
+        }
 
         source_info['position_offset'] = 1.0
     else:

--- a/pizza_cutter/des_pizza_cutter/tests/conftest.py
+++ b/pizza_cutter/des_pizza_cutter/tests/conftest.py
@@ -103,7 +103,7 @@ def se_image_data():
             source_info['image_path'],
             ext=source_info['image_ext'])
         se_wcs_data = {
-            k.lower(): _se_wcs_data[k] for k in _se_wcs_data.keys()}
+            k.lower(): _se_wcs_data[k] for k in _se_wcs_data.keys() if k is not None}
 
         source_info['position_offset'] = 1.0
     else:

--- a/pizza_cutter/des_pizza_cutter/tests/test_se_image_slice_io.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_se_image_slice_io.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import pytest
+import tempfile
 
 import fitsio
 
@@ -15,54 +16,59 @@ from ...memmappednoise import MemMappedNoiseImage
         'SEImageSlice i/o can only be tested if '
         'test data is at TEST_DESDATA'))
 def test_se_image_slice_read(monkeypatch, se_image_data):
-    monkeypatch.setenv(
-        'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
 
-    se_im = SEImageSlice(
-        source_info=se_image_data['source_info'],
-        psf_model=None,
-        wcs=se_image_data['eu_wcs'],
-        wcs_position_offset=1,
-        noise_seed=10,
-        mask_tape_bumps=False,
-    )
-    se_im.set_slice(10, 50, 32)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv(
+            'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
 
-    # check the attributes
-    assert se_im.x_start == 10
-    assert se_im.y_start == 50
-    assert se_im.box_size == 32
+        se_im = SEImageSlice(
+            source_info=se_image_data['source_info'],
+            psf_model=None,
+            wcs=se_image_data['eu_wcs'],
+            wcs_position_offset=1,
+            noise_seed=10,
+            mask_tape_bumps=False,
+            tmpdir=tmpdir,
+        )
+        se_im.set_slice(10, 50, 32)
 
-    # check the images
-    im = fitsio.read(
-        se_image_data['source_info']['image_path'],
-        ext=se_image_data['source_info']['image_ext'])
-    bkg = fitsio.read(
-        se_image_data['source_info']['bkg_path'],
-        ext=se_image_data['source_info']['bkg_ext'])
-    im -= bkg
-    scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
-    im *= scale
-    assert np.array_equal(im[50:82, 10:42], se_im.image)
+        # check the attributes
+        assert se_im.x_start == 10
+        assert se_im.y_start == 50
+        assert se_im.box_size == 32
 
-    wgt = fitsio.read(
-        se_image_data['source_info']['weight_path'],
-        ext=se_image_data['source_info']['weight_ext'])
-    wgt /= scale**2
-    assert np.array_equal(wgt[50:82, 10:42], se_im.weight)
+        # check the images
+        im = fitsio.read(
+            se_image_data['source_info']['image_path'],
+            ext=se_image_data['source_info']['image_ext'])
+        bkg = fitsio.read(
+            se_image_data['source_info']['bkg_path'],
+            ext=se_image_data['source_info']['bkg_ext'])
+        im -= bkg
+        scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
+        im *= scale
+        assert np.array_equal(im[50:82, 10:42], se_im.image)
 
-    bmask = fitsio.read(
-        se_image_data['source_info']['bmask_path'],
-        ext=se_image_data['source_info']['bmask_ext'])
-    assert np.array_equal(bmask[50:82, 10:42], se_im.bmask)
+        wgt = fitsio.read(
+            se_image_data['source_info']['weight_path'],
+            ext=se_image_data['source_info']['weight_ext'])
+        wgt /= scale**2
+        assert np.array_equal(wgt[50:82, 10:42], se_im.weight)
 
-    zmsk = wgt <= 0
-    nse = MemMappedNoiseImage(
-        seed=10,
-        weight=wgt * (~zmsk) + zmsk * np.max(wgt[~zmsk]),
-        sx=1024,
-        sy=1024)
-    assert np.array_equal(nse[50:82, 10:42], se_im.noise)
+        bmask = fitsio.read(
+            se_image_data['source_info']['bmask_path'],
+            ext=se_image_data['source_info']['bmask_ext'])
+        assert np.array_equal(bmask[50:82, 10:42], se_im.bmask)
+
+        zmsk = wgt <= 0
+        nse = MemMappedNoiseImage(
+            seed=10,
+            weight=wgt * (~zmsk) + zmsk * np.max(wgt[~zmsk]),
+            dir=tmpdir,
+            sx=1024,
+            sy=1024,
+        )
+        assert np.array_equal(nse[50:82, 10:42], se_im.noise)
 
 
 @pytest.mark.skipif(
@@ -71,31 +77,34 @@ def test_se_image_slice_read(monkeypatch, se_image_data):
         'SEImageSlice i/o can only be tested if '
         'test data is at TEST_DESDATA'))
 def test_se_image_slice_noise_adjacent(monkeypatch, se_image_data):
-    monkeypatch.setenv(
-        'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv(
+            'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
 
-    se_im = SEImageSlice(
-        source_info=se_image_data['source_info'],
-        psf_model=None,
-        wcs=se_image_data['eu_wcs'],
-        wcs_position_offset=1,
-        noise_seed=10,
-        mask_tape_bumps=False,
-    )
-    se_im.set_slice(10, 50, 30)
+        se_im = SEImageSlice(
+            source_info=se_image_data['source_info'],
+            psf_model=None,
+            wcs=se_image_data['eu_wcs'],
+            wcs_position_offset=1,
+            noise_seed=10,
+            mask_tape_bumps=False,
+            tmpdir=tmpdir,
+        )
+        se_im.set_slice(10, 50, 30)
 
-    se_im_adj = SEImageSlice(
-        source_info=se_image_data['source_info'],
-        psf_model=None,
-        wcs=se_image_data['eu_wcs'],
-        wcs_position_offset=1,
-        noise_seed=10,
-        mask_tape_bumps=False,
-    )
-    se_im_adj.set_slice(20, 50, 30)
+        se_im_adj = SEImageSlice(
+            source_info=se_image_data['source_info'],
+            psf_model=None,
+            wcs=se_image_data['eu_wcs'],
+            wcs_position_offset=1,
+            noise_seed=10,
+            mask_tape_bumps=False,
+            tmpdir=tmpdir,
+        )
+        se_im_adj.set_slice(20, 50, 30)
 
-    # make sure the overlapping parts of the noise field are the same
-    assert np.array_equal(se_im.noise[:, 10:], se_im_adj.noise[:, :-10])
+        # make sure the overlapping parts of the noise field are the same
+        assert np.array_equal(se_im.noise[:, 10:], se_im_adj.noise[:, :-10])
 
 
 @pytest.mark.skipif(
@@ -104,52 +113,54 @@ def test_se_image_slice_noise_adjacent(monkeypatch, se_image_data):
         'SEImageSlice i/o can only be tested if '
         'test data is at TEST_DESDATA'))
 def test_se_image_slice_double_use(monkeypatch, se_image_data):
-    monkeypatch.setenv(
-        'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv(
+            'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
 
-    se_im = SEImageSlice(
-        source_info=se_image_data['source_info'],
-        psf_model=None,
-        wcs=se_image_data['eu_wcs'],
-        wcs_position_offset=1,
-        noise_seed=10,
-        mask_tape_bumps=False,
-    )
+        se_im = SEImageSlice(
+            source_info=se_image_data['source_info'],
+            psf_model=None,
+            wcs=se_image_data['eu_wcs'],
+            wcs_position_offset=1,
+            noise_seed=10,
+            mask_tape_bumps=False,
+            tmpdir=tmpdir,
+        )
 
-    se_im.set_slice(10, 50, 32)
+        se_im.set_slice(10, 50, 32)
 
-    assert se_im.x_start == 10
-    assert se_im.y_start == 50
-    assert se_im.box_size == 32
+        assert se_im.x_start == 10
+        assert se_im.y_start == 50
+        assert se_im.box_size == 32
 
-    im = fitsio.read(
-        se_image_data['source_info']['image_path'],
-        ext=se_image_data['source_info']['image_ext'])
-    bkg = fitsio.read(
-        se_image_data['source_info']['bkg_path'],
-        ext=se_image_data['source_info']['bkg_ext'])
-    im -= bkg
-    scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
-    im *= scale
-    assert np.array_equal(im[50:82, 10:42], se_im.image)
+        im = fitsio.read(
+            se_image_data['source_info']['image_path'],
+            ext=se_image_data['source_info']['image_ext'])
+        bkg = fitsio.read(
+            se_image_data['source_info']['bkg_path'],
+            ext=se_image_data['source_info']['bkg_ext'])
+        im -= bkg
+        scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
+        im *= scale
+        assert np.array_equal(im[50:82, 10:42], se_im.image)
 
-    # now we move to another spot
-    se_im.set_slice(20, 50, 32)
+        # now we move to another spot
+        se_im.set_slice(20, 50, 32)
 
-    assert se_im.x_start == 20
-    assert se_im.y_start == 50
-    assert se_im.box_size == 32
+        assert se_im.x_start == 20
+        assert se_im.y_start == 50
+        assert se_im.box_size == 32
 
-    im = fitsio.read(
-        se_image_data['source_info']['image_path'],
-        ext=se_image_data['source_info']['image_ext'])
-    bkg = fitsio.read(
-        se_image_data['source_info']['bkg_path'],
-        ext=se_image_data['source_info']['bkg_ext'])
-    im -= bkg
-    scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
-    im *= scale
-    assert np.array_equal(im[50:82, 20:52], se_im.image)
+        im = fitsio.read(
+            se_image_data['source_info']['image_path'],
+            ext=se_image_data['source_info']['image_ext'])
+        bkg = fitsio.read(
+            se_image_data['source_info']['bkg_path'],
+            ext=se_image_data['source_info']['bkg_ext'])
+        im -= bkg
+        scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
+        im *= scale
+        assert np.array_equal(im[50:82, 20:52], se_im.image)
 
 
 @pytest.mark.skipif(
@@ -158,58 +169,61 @@ def test_se_image_slice_double_use(monkeypatch, se_image_data):
         'SEImageSlice i/o can only be tested if '
         'test data is at TEST_DESDATA'))
 def test_se_image_slice_two_obj(monkeypatch, se_image_data):
-    monkeypatch.setenv(
-        'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv(
+            'DESDATA', os.path.join(os.environ['TEST_DESDATA'], 'DESDATA'))
 
-    se_im = SEImageSlice(
-        source_info=se_image_data['source_info'],
-        psf_model=None,
-        wcs=se_image_data['eu_wcs'],
-        wcs_position_offset=1,
-        noise_seed=10,
-        mask_tape_bumps=False,
-    )
+        se_im = SEImageSlice(
+            source_info=se_image_data['source_info'],
+            psf_model=None,
+            wcs=se_image_data['eu_wcs'],
+            wcs_position_offset=1,
+            noise_seed=10,
+            mask_tape_bumps=False,
+            tmpdir=tmpdir,
+        )
 
-    se_im.set_slice(10, 50, 32)
+        se_im.set_slice(10, 50, 32)
 
-    assert se_im.x_start == 10
-    assert se_im.y_start == 50
-    assert se_im.box_size == 32
+        assert se_im.x_start == 10
+        assert se_im.y_start == 50
+        assert se_im.box_size == 32
 
-    im = fitsio.read(
-        se_image_data['source_info']['image_path'],
-        ext=se_image_data['source_info']['image_ext'])
-    bkg = fitsio.read(
-        se_image_data['source_info']['bkg_path'],
-        ext=se_image_data['source_info']['bkg_ext'])
-    im -= bkg
-    scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
-    im *= scale
-    assert np.array_equal(im[50:82, 10:42], se_im.image)
+        im = fitsio.read(
+            se_image_data['source_info']['image_path'],
+            ext=se_image_data['source_info']['image_ext'])
+        bkg = fitsio.read(
+            se_image_data['source_info']['bkg_path'],
+            ext=se_image_data['source_info']['bkg_ext'])
+        im -= bkg
+        scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
+        im *= scale
+        assert np.array_equal(im[50:82, 10:42], se_im.image)
 
-    # now we move to another spot
-    se_im1 = SEImageSlice(
-        source_info=se_image_data['source_info'],
-        psf_model=None,
-        wcs=se_image_data['eu_wcs'],
-        wcs_position_offset=1,
-        noise_seed=10,
-        mask_tape_bumps=False,
-    )
+        # now we move to another spot
+        se_im1 = SEImageSlice(
+            source_info=se_image_data['source_info'],
+            psf_model=None,
+            wcs=se_image_data['eu_wcs'],
+            wcs_position_offset=1,
+            noise_seed=10,
+            mask_tape_bumps=False,
+            tmpdir=tmpdir,
+        )
 
-    se_im1.set_slice(20, 50, 32)
+        se_im1.set_slice(20, 50, 32)
 
-    assert se_im1.x_start == 20
-    assert se_im1.y_start == 50
-    assert se_im1.box_size == 32
+        assert se_im1.x_start == 20
+        assert se_im1.y_start == 50
+        assert se_im1.box_size == 32
 
-    im = fitsio.read(
-        se_image_data['source_info']['image_path'],
-        ext=se_image_data['source_info']['image_ext'])
-    bkg = fitsio.read(
-        se_image_data['source_info']['bkg_path'],
-        ext=se_image_data['source_info']['bkg_ext'])
-    im -= bkg
-    scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
-    im *= scale
-    assert np.array_equal(im[50:82, 20:52], se_im1.image)
+        im = fitsio.read(
+            se_image_data['source_info']['image_path'],
+            ext=se_image_data['source_info']['image_ext'])
+        bkg = fitsio.read(
+            se_image_data['source_info']['bkg_path'],
+            ext=se_image_data['source_info']['bkg_ext'])
+        im -= bkg
+        scale = 10.0**(0.4*(MAGZP_REF - se_image_data['source_info']['magzp']))
+        im *= scale
+        assert np.array_equal(im[50:82, 20:52], se_im1.image)

--- a/pizza_cutter/memmappednoise.py
+++ b/pizza_cutter/memmappednoise.py
@@ -1,5 +1,4 @@
 import tempfile
-import os
 import numpy as np
 
 

--- a/pizza_cutter/memmappednoise.py
+++ b/pizza_cutter/memmappednoise.py
@@ -18,9 +18,14 @@ class MemMappedNoiseImage(object):
         Size of patches to generate the noise in the x direction.
     sy : int, optional
         Size of patches to generate the noise in the y direction.
+    dir: string
+        Optional directory to hold the file
     """
 
-    def __init__(self, *, seed, weight, fill_weight=None, sx=1000, sy=1000):
+    def __init__(self, *, seed, weight,
+                 fill_weight=None, sx=1000, sy=1000,
+                 dir=None):
+
         rng = np.random.RandomState(seed=seed)
 
         # generate in chunks so that we don't use a ton of memory
@@ -40,9 +45,12 @@ class MemMappedNoiseImage(object):
         if n_sy * sy < ny:
             n_sy += 1
 
-        # we use a memmapped array on disk to avoid memory usage
-        self._temp = tempfile.TemporaryDirectory()
-        self._fname = os.path.join(self._temp.name, 'arr.dat')
+        if dir is None:
+            tmpdir = tempfile.TemporaryDirectory()
+            dir = tmpdir.name
+
+        self._fname = tempfile.mktemp(dir=dir, suffix='.dat')
+
         self._noise = np.memmap(
             self._fname,
             dtype=np.float32,

--- a/pizza_cutter/tests/test_memmappednoise.py
+++ b/pizza_cutter/tests/test_memmappednoise.py
@@ -45,7 +45,8 @@ def test_memmappednoise_fill(bad_value):
 
         assert np.std(ns[0:50, :]) < np.std(ns[50:, :])
 
-        # the noise should be close to 3, but ofc it is noise so within 0.1 is fine
+        # the noise should be close to 3, but ofc it is noise so within 0.1 is
+        # fine
         assert np.abs(np.std(ns[0:50, :]) - 3) < 0.1
 
 

--- a/pizza_cutter/tests/test_memmappednoise.py
+++ b/pizza_cutter/tests/test_memmappednoise.py
@@ -1,3 +1,4 @@
+import tempfile
 import numpy as np
 import pytest
 
@@ -5,104 +6,158 @@ from ..memmappednoise import MemMappedNoiseImage
 
 
 def test_memmappednoise_smoke():
-    weight = np.ones((100, 100)) * 0.0001
-    ns = MemMappedNoiseImage(seed=10, weight=weight, sx=10, sy=10)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        weight = np.ones((100, 100)) * 0.0001
+        ns = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=10,
+            sy=10,
+            dir=tmpdir,
+        )
 
-    ns1 = ns[0, 0]
-    ns2 = ns[0, 0]
-    assert ns1 == ns2
+        ns1 = ns[0, 0]
+        ns2 = ns[0, 0]
+        assert ns1 == ns2
 
-    ns1 = ns[0, 0:10]
-    ns2 = ns[0, 0:10]
-    assert np.all(ns1 == ns2)
+        ns1 = ns[0, 0:10]
+        ns2 = ns[0, 0:10]
+        assert np.all(ns1 == ns2)
 
-    ns1 = ns[0:5, 0:93]
-    ns2 = ns[0, 0:93]
-    assert np.all(ns1[0, :] == ns2)
+        ns1 = ns[0:5, 0:93]
+        ns2 = ns[0, 0:93]
+        assert np.all(ns1[0, :] == ns2)
 
 
 @pytest.mark.parametrize('bad_value', [0.0, -10])
 def test_memmappednoise_fill(bad_value):
-    weight = np.ones((100, 100)) * 0.0001
-    weight[0:50, :] = bad_value
-    ns = MemMappedNoiseImage(
-        seed=10, weight=weight, sx=10, sy=10, fill_weight=1/9)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        weight = np.ones((100, 100)) * 0.0001
+        weight[0:50, :] = bad_value
+        ns = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=10,
+            sy=10,
+            fill_weight=1/9,
+            dir=tmpdir,
+        )
 
-    assert np.std(ns[0:50, :]) < np.std(ns[50:, :])
+        assert np.std(ns[0:50, :]) < np.std(ns[50:, :])
 
-    # the noise should be close to 3, but ofc it is noise so within 0.1 is fine
-    assert np.abs(np.std(ns[0:50, :]) - 3) < 0.1
+        # the noise should be close to 3, but ofc it is noise so within 0.1 is fine
+        assert np.abs(np.std(ns[0:50, :]) - 3) < 0.1
 
 
 def test_memmappednoise_seeding():
-    weight = np.ones((100, 100)) * 0.0001
-    ns1 = MemMappedNoiseImage(seed=10, weight=weight, sx=10, sy=10)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        weight = np.ones((100, 100)) * 0.0001
+        ns1 = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=10,
+            sy=10,
+            dir=tmpdir,
+        )
 
-    weight = np.ones((100, 100)) * 0.0001
-    ns2 = MemMappedNoiseImage(seed=10, weight=weight, sx=10, sy=10)
+        weight = np.ones((100, 100)) * 0.0001
+        ns2 = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=10,
+            sy=10,
+            dir=tmpdir,
+        )
 
-    assert ns1[0, 0] == ns2[0, 0]
-    assert np.all(ns1[0, 0:10] == ns2[0, 0:10])
-    assert np.all(ns1[0:5, 0:24] == ns2[0:5, 0:24])
+        assert ns1[0, 0] == ns2[0, 0]
+        assert np.all(ns1[0, 0:10] == ns2[0, 0:10])
+        assert np.all(ns1[0:5, 0:24] == ns2[0:5, 0:24])
 
-    weight = np.ones((100, 100)) * 0.0001
-    ns2 = MemMappedNoiseImage(seed=20, weight=weight, sx=10, sy=10)
+        weight = np.ones((100, 100)) * 0.0001
+        ns2 = MemMappedNoiseImage(
+            seed=20,
+            weight=weight,
+            sx=10,
+            sy=10,
+            dir=tmpdir,
+        )
 
-    assert ns1[0, 0] != ns2[0, 0]
-    assert not np.all(ns1[0, 0:10] == ns2[0, 0:10])
-    assert not np.all(ns1[0:5, 0:24] == ns2[0:5, 0:24])
+        assert ns1[0, 0] != ns2[0, 0]
+        assert not np.all(ns1[0, 0:10] == ns2[0, 0:10])
+        assert not np.all(ns1[0:5, 0:24] == ns2[0:5, 0:24])
 
 
 def test_memmappednoise_sizes_same():
-    weight = np.ones((100, 100)) * 0.0001
-    ns = MemMappedNoiseImage(seed=10, weight=weight, sx=100, sy=100)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        weight = np.ones((100, 100)) * 0.0001
+        ns = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=100,
+            sy=100,
+            dir=tmpdir,
+        )
 
-    ns1 = ns[0, 0]
-    ns2 = ns[0, 0]
-    assert ns1 == ns2
+        ns1 = ns[0, 0]
+        ns2 = ns[0, 0]
+        assert ns1 == ns2
 
-    ns1 = ns[0, 0:10]
-    ns2 = ns[0, 0:10]
-    assert np.all(ns1 == ns2)
+        ns1 = ns[0, 0:10]
+        ns2 = ns[0, 0:10]
+        assert np.all(ns1 == ns2)
 
-    ns1 = ns[0:5, 0:93]
-    ns2 = ns[0, 0:93]
-    assert np.all(ns1[0, :] == ns2)
+        ns1 = ns[0:5, 0:93]
+        ns2 = ns[0, 0:93]
+        assert np.all(ns1[0, :] == ns2)
 
 
 def test_memmappednoise_sizes_different():
-    weight = np.ones((100, 100)) * 0.0001
-    ns = MemMappedNoiseImage(seed=10, weight=weight, sx=25, sy=10)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        weight = np.ones((100, 100)) * 0.0001
+        ns = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=25,
+            sy=10,
+            dir=tmpdir,
+        )
 
-    ns1 = ns[0, 0]
-    ns2 = ns[0, 0]
-    assert ns1 == ns2
+        ns1 = ns[0, 0]
+        ns2 = ns[0, 0]
+        assert ns1 == ns2
 
-    ns1 = ns[0, 0:10]
-    ns2 = ns[0, 0:10]
-    assert np.all(ns1 == ns2)
+        ns1 = ns[0, 0:10]
+        ns2 = ns[0, 0:10]
+        assert np.all(ns1 == ns2)
 
-    ns1 = ns[0:5, 0:93]
-    ns2 = ns[0, 0:93]
-    assert np.all(ns1[0, :] == ns2)
+        ns1 = ns[0:5, 0:93]
+        ns2 = ns[0, 0:93]
+        assert np.all(ns1[0, :] == ns2)
 
 
 def test_memmappednoise_sizes_weird():
-    weight = np.ones((100, 100)) * 0.0001
-    ns = MemMappedNoiseImage(seed=10, weight=weight, sx=74, sy=1000)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        weight = np.ones((100, 100)) * 0.0001
+        ns = MemMappedNoiseImage(
+            seed=10,
+            weight=weight,
+            sx=74,
+            sy=1000,
+            dir=tmpdir,
+        )
 
-    ns1 = ns[0, 0]
-    ns2 = ns[0, 0]
-    assert ns1 == ns2
+        ns1 = ns[0, 0]
+        ns2 = ns[0, 0]
+        assert ns1 == ns2
 
-    ns1 = ns[0, 0:10]
-    ns2 = ns[0, 0:10]
-    assert np.all(ns1 == ns2)
+        ns1 = ns[0, 0:10]
+        ns2 = ns[0, 0:10]
+        assert np.all(ns1 == ns2)
 
-    ns1 = ns[0:5, 0:93]
-    ns2 = ns[0, 0:93]
-    assert np.all(ns1[0, :] == ns2)
+        ns1 = ns[0:5, 0:93]
+        ns2 = ns[0, 0:93]
+        assert np.all(ns1[0, :] == ns2)
 
-    # if we missed any elements, they would be exactly zero
-    ns1 = ns[:, :]
-    assert not np.any(ns1 == 0)
+        # if we missed any elements, they would be exactly zero
+        ns1 = ns[:, :]
+        assert not np.any(ns1 == 0)


### PR DESCRIPTION
closes #144 

propagate down to SEImage and MemMapped noise etc. so that
the same dir can be used

the mem mapped noise can still be used as before; it will generate
its own temp dir if not sent