### PR TITLE
enable compressed sensing interpolant

### DIFF
--- a/config_files/des-pizza-slices-y3-cs-fourier-interp.yaml
+++ b/config_files/des-pizza-slices-y3-cs-fourier-interp.yaml
@@ -58,7 +58,7 @@ single_epoch:
   # "SUSPECT":   2048,  #/* nominally useful pixel but not perfect    */
   # Note that SUSPECT includes tape bumps
 
-  interp_type: cubic
+  interp_type: 'cs-fourier'
 
   spline_interp_flags:
     - 1     # BPM

--- a/config_files/des-pizza-slices-y5.yaml
+++ b/config_files/des-pizza-slices-y5.yaml
@@ -57,6 +57,8 @@ single_epoch:
   # "SUSPECT":   2048,  #/* nominally useful pixel but not perfect    */
   # "TAPEBUMP": 16384,  #/* tape bumps                                */
 
+  interp_type: cubic
+
   spline_interp_flags:
     - 1     # BPM
     - 2     # SATURATE

--- a/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
+++ b/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
@@ -243,6 +243,7 @@ def _coadd_and_write_images(
             spline_interp_flags=sum(
                 single_epoch_config['spline_interp_flags']),
             bad_image_flags=sum(single_epoch_config['bad_image_flags']),
+            interp_type=single_epoch_config['interp_type'],
             max_masked_fraction=single_epoch_config['max_masked_fraction'],
             max_unmasked_trail_fraction=single_epoch_config[
                 'max_unmasked_trail_fraction'],

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -47,6 +47,8 @@ single_epoch:
 
   mask_tape_bumps: False
 
+  interp_type: cubic
+
   spline_interp_flags:
     - 2
 

--- a/pizza_cutter/des_pizza_cutter/tests/conftest.py
+++ b/pizza_cutter/des_pizza_cutter/tests/conftest.py
@@ -103,7 +103,9 @@ def se_image_data():
             source_info['image_path'],
             ext=source_info['image_ext'])
         se_wcs_data = {
-            k.lower(): _se_wcs_data[k] for k in _se_wcs_data.keys()}
+            k.lower(): _se_wcs_data[k]
+            for k in _se_wcs_data.keys()
+            if k is not None}
 
         source_info['position_offset'] = 1.0
     else:

--- a/pizza_cutter/slice_utils/cs_interpolate.py
+++ b/pizza_cutter/slice_utils/cs_interpolate.py
@@ -1,0 +1,106 @@
+import numpy as np
+import scipy.fftpack as spfft
+from lbfgs import fmin_lbfgs
+
+
+def _dct2(x):
+    "A 2d discrete cosine transform."
+    return spfft.dct(spfft.dct(x, axis=0, norm='ortho'), axis=1, norm='ortho')
+
+
+def _idct2(x):
+    "An inverse 2d discrete cosine transform."
+    return spfft.idct(
+        spfft.idct(x, axis=0, norm='ortho'), axis=1, norm='ortho')
+
+
+def _interpolate_image_cs(image, sample_mask, c=15):
+    ri_vector, = np.where(sample_mask.ravel())
+    b_vector = image.ravel()[ri_vector].copy()
+    image_dims = image.shape
+
+    def _evaluate(x, g):
+        # return squared norm of residuals and set the gradient
+        x2 = x.reshape(image_dims)
+        Ax2 = _idct2(x2)
+        Ax = Ax2.flat[ri_vector]
+        Axb = Ax - b_vector
+        fx = np.sum(np.power(Axb, 2))
+        Axb2 = np.zeros(x2.shape)
+        Axb2.flat[ri_vector] = Axb
+        AtAxb2 = 2 * _dct2(Axb2)
+        AtAxb = AtAxb2.reshape(x.shape)
+
+        np.copyto(g, AtAxb)
+        return fx
+
+    x0 = np.zeros_like(image).ravel()
+    x = fmin_lbfgs(_evaluate, x0, orthantwise_c=c, line_search='wolfe')
+
+    # transform the output back into the spatial domain
+    x = _idct2(x.reshape(image_dims))
+
+    return x
+
+
+def interpolate_image_and_noise_cs(
+        *, image, noise, weight, bmask, bad_flags, rng,
+        sampling_rate=1, c=100):
+    """Interpolate an image and a noise field using compressed sensing in the
+    Fourier domain.
+
+    Parameters
+    ----------
+    image : array-like
+        The image to interpolate.
+    noise : array-like
+        The noise field to interpolate.
+    weight : array-like
+        A weight map to test for zero values. Any pixels with zero weight
+        are interpolated.
+    bmask : array-like
+        The bit mask for the slice.
+    bad_flags : int
+        Pixels with in the bit mask using
+        `(bmask & bad_flags) != 0`.
+    rng : `numpy.random.RandomState`
+        An RNG instance to use.
+    sampling_rate : float
+        The rate at which to sample the good pixels for the solver.
+    c : float
+        The weight of the L1 penalty in the compressed sensing loss.
+
+    Returns
+    -------
+    interp_image : array-like
+        The interpolated image.
+    interp_noise : array-like
+        The interpolated noise image.
+    """
+    bad_mask = (weight <= 0) | ((bmask & bad_flags) != 0)
+
+    if np.any(bad_mask):
+        # get the pixels to sample
+        good_mask = ~bad_mask
+        good_inds = np.where(good_mask)
+        assert np.all(good_mask[good_inds[0], good_inds[1]])
+
+        n_sample = int(np.ceil(len(good_inds[0]) * sampling_rate))
+        assert n_sample > 0
+
+        sample_mask = np.zeros(image.shape)
+        inds = rng.choice(len(good_inds[0]), replace=False, size=n_sample)
+        sample_mask[good_inds[0][inds], good_inds[1][inds]] = 1
+        sample_mask = sample_mask.astype(np.bool)
+
+        # interpolate
+        interp_image = _interpolate_image_cs(image, sample_mask, c=c)
+        interp_image[good_mask] = image[good_mask]
+
+        interp_noise = _interpolate_image_cs(noise, sample_mask, c=c)
+        interp_noise[good_mask] = noise[good_mask]
+
+        return interp_image, interp_noise
+    else:
+        # return a copy here since the caller expects new images
+        return image.copy(), noise.copy()

--- a/pizza_cutter/slice_utils/tests/test_cs_interpolate.py
+++ b/pizza_cutter/slice_utils/tests/test_cs_interpolate.py
@@ -1,0 +1,172 @@
+import numpy as np
+
+from ..cs_interpolate import interpolate_image_and_noise_cs
+
+
+def test_interpolate_image_and_noise_cs_weight():
+    # linear image interp should be perfect for regions smaller than the
+    # patches used for interpolation
+    y, x = np.mgrid[0:100, 0:100]
+    image = (10 + x*5).astype(np.float32)
+    weight = np.ones_like(image)
+    bmask = np.zeros_like(image, dtype=np.int32)
+    bad_flags = 0
+    weight[30:35, 40:45] = 0.0
+
+    # put nans here to make sure interp is done ok
+    msk = weight <= 0
+    image[msk] = np.nan
+
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    iimage, inoise = interpolate_image_and_noise_cs(
+        image=image,
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        noise=noise,
+        rng=np.random.RandomState(seed=45),
+        c=1)
+
+    assert np.allclose(iimage, 10 + x*5, atol=0.01, rtol=0)
+
+    # make sure noise field was inteprolated
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    assert not np.allclose(noise[msk], inoise[msk])
+    assert np.allclose(noise[~msk], inoise[~msk])
+
+
+def test_interpolate_image_and_noise_cs_bmask():
+    # linear image interp should be perfect for regions smaller than the
+    # patches used for interpolation
+    y, x = np.mgrid[0:100, 0:100]
+    image = (10 + x*5).astype(np.float32)
+    weight = np.ones_like(image)
+    bmask = np.zeros_like(image, dtype=np.int32)
+    bad_flags = 1
+
+    rng = np.random.RandomState(seed=42)
+    bmask[30:35, 40:45] = 1
+    bmask[:, 0] = 2
+    bmask[:, -1] = 4
+
+    # put nans here to make sure interp is done ok
+    msk = (bmask & bad_flags) != 0
+    image[msk] = np.nan
+
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    iimage, inoise = interpolate_image_and_noise_cs(
+        image=image,
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        noise=noise,
+        rng=np.random.RandomState(seed=45),
+        c=1)
+
+    assert np.allclose(iimage, 10 + x*5, atol=0.01, rtol=0)
+
+    # make sure noise field was inteprolated
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    assert not np.allclose(noise[msk], inoise[msk])
+    assert np.allclose(noise[~msk], inoise[~msk])
+
+
+def test_interpolate_image_and_noise_cs_big_missing():
+    y, x = np.mgrid[0:100, 0:100]
+    image = (10 + x*5).astype(np.float32)
+    weight = np.ones_like(image)
+    bmask = np.zeros_like(image, dtype=np.int32)
+    bad_flags = 1
+
+    rng = np.random.RandomState(seed=42)
+    nse = rng.normal(size=image.shape)
+    bmask[15:80, 15:80] = 1
+
+    # put nans here to make sure interp is done ok
+    msk = (bmask & bad_flags) != 0
+    image[msk] = np.nan
+
+    iimage, inoise = interpolate_image_and_noise_cs(
+        image=image,
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        noise=nse,
+        rng=np.random.RandomState(seed=45))
+
+    # interp will be waaay off but should have happened
+    assert np.all(np.isfinite(iimage))
+
+    # make sure noise field was inteprolated
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    assert not np.allclose(noise[msk], inoise[msk])
+    assert np.allclose(noise[~msk], inoise[~msk])
+
+
+def test_interpolate_image_and_noise_cs_gauss(show=False):
+    """
+    test that our interpolation works decently for a linear
+    piece missing from a gaussian image
+    """
+
+    rng = np.random.RandomState(seed=31415)
+    noise = 0.001
+
+    sigma = 4.0
+    is2 = 1.0/sigma**2
+    dims = 51, 51
+    cen = (np.array(dims)-1.0)/2.0
+
+    rows, cols = np.mgrid[
+        0:dims[0],
+        0:dims[1],
+    ]
+    rows = rows - cen[0]
+    cols = cols - cen[1]
+
+    image_unmasked = np.exp(-0.5*(rows**2 + cols**2)*is2)
+    weight = image_unmasked*0 + 1.0/noise**2
+
+    noise_image = rng.normal(scale=noise, size=image_unmasked.shape)
+
+    badcol = int(cen[1]-3)
+    bw = 3
+    rr = badcol-bw, badcol+bw+1
+
+    weight[rr[0]:rr[1], badcol] = 0.0
+    image_masked = image_unmasked.copy()
+    image_masked[rr[0]:rr[1], badcol] = 0.0
+
+    bmask = np.zeros_like(image_unmasked, dtype=np.int32)
+    bad_flags = 0
+
+    iimage, inoise = interpolate_image_and_noise_cs(
+        image=image_masked,
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        noise=noise_image,
+        rng=np.random.RandomState(seed=45),
+        c=1,
+    )
+
+    maxdiff = np.abs(image_unmasked-iimage).max()
+
+    if show:
+        import images
+        images.view_mosaic([image_masked, weight])
+
+        images.compare_images(
+            image_unmasked,
+            iimage,
+            width=2000,
+            height=int(2000*2/3),
+        )
+        print('max diff:', maxdiff)
+
+    assert maxdiff < 0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ joblib
 jinja2
 blosc
 tqdm
+pylbfgs
 git+https://github.com/rmjarvis/Piff.git@master
 git+https://github.com/gbernstein/pixmappy.git


### PR DESCRIPTION
This PR enables the compressed sensing interpolant. See the config file here https://github.com/beckermr/pizza-cutter/blob/cs_interp/config_files/des-pizza-slices-y3-cs-fourier-interp.yaml

with the `interp_type` option which can either be `cubic` or `cs-fourier`.

@esheldon for viz