### PR TITLE
ENH interpolate masked edges via a copy

### DIFF
--- a/config_files/des-pizza-slices-y3.yaml
+++ b/config_files/des-pizza-slices-y3.yaml
@@ -42,6 +42,7 @@ single_epoch:
 
   reject_outliers: False
   symmetrize_masking: True
+  copy_masked_edges: False
   max_masked_fraction: 0.1
   max_unmasked_trail_fraction: 0.02
   edge_buffer: 64

--- a/config_files/des-pizza-slices-y5.yaml
+++ b/config_files/des-pizza-slices-y5.yaml
@@ -27,7 +27,7 @@ single_epoch:
   # pixel spacing for building various WCS interpolants
   se_wcs_interp_delta: 8
   coadd_wcs_interp_delta: 100
-  
+
   # fractional amount to increase coadd box size when getting SE region for
   # coadding - set to sqrt(2) for full position angle rotations
   frac_buffer: 1
@@ -41,6 +41,7 @@ single_epoch:
 
   reject_outliers: False
   symmetrize_masking: True
+  copy_masked_edges: False
   max_masked_fraction: 0.1
   max_unmasked_trail_fraction: 0.02
   edge_buffer: 64

--- a/config_files/des-pizza-slices-y6-v1.yaml
+++ b/config_files/des-pizza-slices-y6-v1.yaml
@@ -27,7 +27,7 @@ single_epoch:
   # pixel spacing for building various WCS interpolants
   se_wcs_interp_delta: 8
   coadd_wcs_interp_delta: 100
-  
+
   # fractional amount to increase coadd box size when getting SE region for
   # coadding - set to sqrt(2) for full position angle rotations
   frac_buffer: 1
@@ -42,6 +42,7 @@ single_epoch:
 
   reject_outliers: False
   symmetrize_masking: True
+  copy_masked_edges: False
   max_masked_fraction: 0.1
   max_unmasked_trail_fraction: 0.02
   edge_buffer: 64

--- a/config_files/des-pizza-slices-y6-v2.yaml
+++ b/config_files/des-pizza-slices-y6-v2.yaml
@@ -27,7 +27,7 @@ single_epoch:
   # pixel spacing for building various WCS interpolants
   se_wcs_interp_delta: 8
   coadd_wcs_interp_delta: 100
-  
+
   # fractional amount to increase coadd box size when getting SE region for
   # coadding - set to sqrt(2) for full position angle rotations
   frac_buffer: 1
@@ -42,6 +42,7 @@ single_epoch:
 
   reject_outliers: False
   symmetrize_masking: True
+  copy_masked_edges: False
   max_masked_fraction: 0.1
   max_unmasked_trail_fraction: 0.02
   edge_buffer: 64

--- a/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
+++ b/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
@@ -236,6 +236,7 @@ def _coadd_and_write_images(
             reject_outliers=single_epoch_config['reject_outliers'],
             symmetrize_masking=single_epoch_config['symmetrize_masking'],
             coadding_weight=coadding_weight,
+            copy_masked_edges=single_epoch_config['copy_masked_edges'],
             noise_interp_flags=sum(single_epoch_config['noise_interp_flags']),
             spline_interp_flags=sum(
                 single_epoch_config['spline_interp_flags']),

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -46,6 +46,7 @@ single_epoch:
 
   reject_outliers: False
   symmetrize_masking: True
+  copy_masked_edges: False
   max_masked_fraction: 0.1
   max_unmasked_trail_fraction: 0.02
   edge_buffer: 8

--- a/pizza_cutter/slice_utils/interpolate.py
+++ b/pizza_cutter/slice_utils/interpolate.py
@@ -168,8 +168,6 @@ def interpolate_image_and_noise(
     bad_flags : int
         Pixels with in the bit mask using
         `(bmask & bad_flags) != 0`.
-    rng : `numpy.random.RandomState`
-        An RNG instance to use.
 
     Returns
     -------
@@ -194,3 +192,49 @@ def interpolate_image_and_noise(
     else:
         # return a copy here since the caller expects new images
         return image.copy(), noise.copy()
+
+
+def copy_masked_edges_image_and_noise(
+    *, image, noise, weight, bmask, bad_flags
+):
+    """Any edge that is fully masked or has all weights zero
+    has the adjacent pixels copied into it.
+
+    Parameters
+    ----------
+    image : array-like
+        The image to interpolate.
+    noise : array-like
+        A noise field to interpolate in the same way as the image.
+    weight : array-like
+        A weight map to test for zero values. Any pixels with zero weight
+        are interpolated.
+    bmask : array-like
+        The bit mask for the slice.
+    bad_flags : int
+        Pixels with in the bit mask using
+        `(bmask & bad_flags) != 0`.
+
+    Returns
+    -------
+    interp_image : array-like
+        The interpolated image.
+    interp_noise : array-like
+        The interpolated noise field.
+    """
+    interp_image, interp_noise = image.copy(), noise.copy()
+    for i, ii in [(0, 1), (-1, -2)]:
+        bad_msk = (weight[i, :] <= 0) | ((bmask[i, :] & bad_flags) != 0)
+        if np.all(bad_msk):
+            logger.debug('doing msk edge interpolation row %d', i)
+
+            interp_image[i, :] = interp_image[ii, :]
+            interp_noise[i, :] = interp_noise[ii, :]
+
+        bad_msk = (weight[:, i] <= 0) | ((bmask[:, i] & bad_flags) != 0)
+        if np.all(bad_msk):
+            logger.debug('doing msk edge interpolation col %d', i)
+            interp_image[:, i] = interp_image[:, ii]
+            interp_noise[:, i] = interp_noise[:, ii]
+
+    return interp_image, interp_noise

--- a/pizza_cutter/slice_utils/tests/test_interpolate.py
+++ b/pizza_cutter/slice_utils/tests/test_interpolate.py
@@ -1,6 +1,11 @@
 import numpy as np
 
-from ..interpolate import interpolate_image_and_noise
+import pytest
+
+from ..interpolate import (
+    interpolate_image_and_noise,
+    copy_masked_edges_image_and_noise,
+)
 
 
 def test_interpolate_image_and_noise_weight():
@@ -163,3 +168,72 @@ def test_interpolate_gauss_image(show=False):
         print('max diff:', maxdiff)
 
     assert maxdiff < 0.0015
+
+
+@pytest.mark.parametrize("kind", ["x", "y"])
+@pytest.mark.parametrize("i,ii", [(0, 1), (-1, -2)])
+def test_copy_masked_edges_image_and_noise_weight(i, ii, kind):
+    rng = np.random.RandomState(seed=56)
+    image = rng.uniform(size=(100, 100))
+    weight = np.ones_like(image)
+    bmask = np.zeros_like(image, dtype=np.int32)
+    bad_flags = 0
+    if kind == "x":
+        weight[:, i] = 0
+    else:
+        weight[i, :] = 0
+
+    # put nans here to make sure interp is done ok
+    msk = weight <= 0
+    image[msk] = np.nan
+
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    iimage, inoise = copy_masked_edges_image_and_noise(
+        image=image,
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        noise=noise)
+
+    if kind == "x":
+        assert np.allclose(iimage[:, i], image[:, ii])
+        assert np.allclose(inoise[:, i], noise[:, ii])
+    else:
+        assert np.allclose(iimage[i, :], image[ii, :])
+        assert np.allclose(inoise[i, :], noise[ii, :])
+
+
+@pytest.mark.parametrize("kind", ["x", "y"])
+@pytest.mark.parametrize("i,ii", [(0, 1), (-1, -2)])
+def test_copy_masked_edges_image_and_noise_bmask(i, ii, kind):
+    rng = np.random.RandomState(seed=56)
+    image = rng.uniform(size=(100, 100))
+    weight = np.ones_like(image)
+    bmask = np.zeros_like(image, dtype=np.int32)
+    bad_flags = 1
+    bmask[30:35, 40:45] = 4
+    if kind == "x":
+        bmask[:, i] = bad_flags
+    else:
+        bmask[i, :] = bad_flags
+
+    # put nans here to make sure interp is done ok
+    msk = (bmask & bad_flags) != 0
+    image[msk] = np.nan
+
+    rng = np.random.RandomState(seed=42)
+    noise = rng.normal(size=image.shape)
+    iimage, inoise = copy_masked_edges_image_and_noise(
+        image=image,
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        noise=noise)
+
+    if kind == "x":
+        assert np.allclose(iimage[:, i], image[:, ii])
+        assert np.allclose(inoise[:, i], noise[:, ii])
+    else:
+        assert np.allclose(iimage[i, :], image[ii, :])
+        assert np.allclose(inoise[i, :], noise[ii, :])

--- a/pizza_cutter/slice_utils/tests/test_interpolate.py
+++ b/pizza_cutter/slice_utils/tests/test_interpolate.py
@@ -189,7 +189,7 @@ def test_copy_masked_edges_image_and_noise_weight(i, ii, kind):
 
     rng = np.random.RandomState(seed=42)
     noise = rng.normal(size=image.shape)
-    iimage, inoise = copy_masked_edges_image_and_noise(
+    iimage, inoise, ibmask, iweight = copy_masked_edges_image_and_noise(
         image=image,
         weight=weight,
         bmask=bmask,
@@ -199,9 +199,13 @@ def test_copy_masked_edges_image_and_noise_weight(i, ii, kind):
     if kind == "x":
         assert np.allclose(iimage[:, i], image[:, ii])
         assert np.allclose(inoise[:, i], noise[:, ii])
+        assert np.allclose(ibmask[:, i], bmask[:, ii])
+        assert np.allclose(iweight[:, i], weight[:, ii])
     else:
         assert np.allclose(iimage[i, :], image[ii, :])
         assert np.allclose(inoise[i, :], noise[ii, :])
+        assert np.allclose(ibmask[i, :], bmask[ii, :])
+        assert np.allclose(iweight[i, :], weight[ii, :])
 
 
 @pytest.mark.parametrize("kind", ["x", "y"])
@@ -224,7 +228,7 @@ def test_copy_masked_edges_image_and_noise_bmask(i, ii, kind):
 
     rng = np.random.RandomState(seed=42)
     noise = rng.normal(size=image.shape)
-    iimage, inoise = copy_masked_edges_image_and_noise(
+    iimage, inoise, ibmask, iweight = copy_masked_edges_image_and_noise(
         image=image,
         weight=weight,
         bmask=bmask,
@@ -234,6 +238,10 @@ def test_copy_masked_edges_image_and_noise_bmask(i, ii, kind):
     if kind == "x":
         assert np.allclose(iimage[:, i], image[:, ii])
         assert np.allclose(inoise[:, i], noise[:, ii])
+        assert np.allclose(ibmask[:, i], bmask[:, ii])
+        assert np.allclose(iweight[:, i], weight[:, ii])
     else:
         assert np.allclose(iimage[i, :], image[ii, :])
         assert np.allclose(inoise[i, :], noise[ii, :])
+        assert np.allclose(ibmask[i, :], bmask[ii, :])
+        assert np.allclose(iweight[i, :], weight[ii, :])


### PR DESCRIPTION
This will interpolate any edge of fully masked pixels by making a copy of the ones just inside the edge. This is really useful to avoid chucking a SE image just because of a bad column in a bad spot. 

cc @esheldon 