### PR TITLE
Star masking

### DIFF
--- a/config_files/des-pizza-slices-y6-v4.yaml
+++ b/config_files/des-pizza-slices-y6-v4.yaml
@@ -1,0 +1,103 @@
+des_data:
+  campaign: Y6A2_COADD
+  source_type: finalcut
+
+# optional but these are good defaults
+fpack_pars:
+  FZQVALUE: 4
+  FZTILE: "(10240,1)"
+  FZALGOR: "RICE_1"
+  # preserve zeros, don't dither them
+  FZQMETHD: "SUBTRACTIVE_DITHER_2"
+
+coadd:
+  # these are in pixels
+  # the total "pizza slice" will be central_size + 2 * buffer_size
+  central_size: 100  # size of the central region
+  buffer_size: 50  # size of the buffer on each size
+
+  # this should be odd and bigger than any stamp returned by the
+  # PSF reconstruction
+  psf_box_size: 51
+
+  wcs_type: image
+  coadding_weight: 'noise'
+
+single_epoch:
+  # pixel spacing for building various WCS interpolants
+  se_wcs_interp_delta: 8
+  coadd_wcs_interp_delta: 100
+
+  # fractional amount to increase coadd box size when getting SE region for
+  # coadding - set to sqrt(2) for full position angle rotations
+  frac_buffer: 1
+
+  # set this to either piff or psfex
+  # if using piff in DES and a release earlier than Y6,
+  # you need to set the piff_run above too
+  psf_type: piff
+
+  # which SE WCS to use - one of piff, pixmappy or image
+  wcs_type: pixmappy
+
+  reject_outliers: False
+  symmetrize_masking: True
+  copy_masked_edges: False
+  max_masked_fraction: 0.1
+  max_unmasked_trail_fraction: 0.02
+  edge_buffer: 64
+
+  # Y6 already deals with tapebump in a sensible way
+  mask_tape_bumps: False
+
+  # DES Y6 bit mask flags
+  # "BPM":          1,  #/* set in bpm (hot/dead pixel/column)        */
+  # "SATURATE":     2,  #/* saturated pixel                           */
+  # "INTERP":       4,  #/* interpolated pixel                        */
+  # "BADAMP":       8,  #/* Data from non-functional amplifier        */
+  # "CRAY":        16,  #/* cosmic ray pixel                          */
+  # "STAR":        32,  #/* bright star pixel                         */
+  # "TRAIL":       64,  #/* bleed trail pixel                         */
+  # "EDGEBLEED":  128,  #/* edge bleed pixel                          */
+  # "SSXTALK":    256,  #/* pixel potentially effected by xtalk from  */
+  #                     #/*       a super-saturated source            */
+  # "EDGE":       512,  #/* pixel flag to exclude CCD glowing edges   */
+  # "STREAK":    1024,  #/* pixel associated with streak from a       */
+  #                     #/*       satellite, meteor, ufo...           */
+  # "SUSPECT":   2048,  #/* nominally useful pixel but not perfect    */
+  # "TAPEBUMP": 16384,  #/* tape bumps                                */
+
+  spline_interp_flags:
+    - 1     # BPM
+    - 2     # SATURATE
+    - 16    # CRAY
+    - 64    # TRAIL
+    - 1024  # STREAK
+    - 2048  # SUSPECT
+
+  noise_interp_flags:
+    - 4     # INTERP. Already interpolated; is this ever set?
+    - 8     # BADAMP
+    - 128   # EDGEBLEED
+    - 256   # SSXTALK
+    - 512   # EDGE
+
+  # make the judgment call that it is better to use the somewhat
+  # suspect TAPEBUMP areas than fill with noise, because they are
+  # fairly large
+  #  - 16384 # TAPEBUMP
+
+  bad_image_flags:
+    - 0
+
+gaia_star_masks:
+  # multiply the radii by this factor
+  radius_factor: 1.5
+
+  # don't mask stars with gaia g mag less than this
+  max_g_mag: 18.0
+
+  # coefficients for log10(radius) vs mag.  Don't change this unless
+  # you know what you are doing
+  poly_coeffs: [0.00443223, -0.22569131, 2.99642999]
+

--- a/config_files/des-pizza-slices-y6-v4.yaml
+++ b/config_files/des-pizza-slices-y6-v4.yaml
@@ -92,7 +92,7 @@ single_epoch:
 
 gaia_star_masks:
   # multiply the radii by this factor
-  radius_factor: 1.5
+  radius_factor: 1.75
 
   # don't mask stars with gaia g mag less than this
   max_g_mag: 18.0

--- a/pizza_cutter/des_pizza_cutter/_coadd_slices.py
+++ b/pizza_cutter/des_pizza_cutter/_coadd_slices.py
@@ -20,6 +20,7 @@ from ..slice_utils.flag import (
 from ..slice_utils.interpolate import (
     interpolate_image_and_noise,
     copy_masked_edges_image_and_noise,
+    _grid_interp,
 )
 from ..slice_utils.symmetrize import (
     symmetrize_bmask,
@@ -569,13 +570,19 @@ def _coadd_slice_inputs(
     weight[:, :] = 1.0 / np.var(noise)
 
     if gaia_stars_file is not None:
-        _mask_gaia_stars(
+        # weight is modified in place
+        image, noise = _mask_gaia_stars(
             gaia_stars_file=gaia_stars_file,
-            wcs=wcs,
-            row_cen=(start_row + box_size/2),
-            col_cen=(start_col + box_size/2),
+            image=image,
+            weight=weight,
+            noise=noise,
             bmask=bmask,
+            ormask=ormask,
+            wcs=wcs,
+            start_row=start_row,
+            start_col=start_col,
             gaia_mask_config=gaia_mask_config,
+            wcs_position_offset=wcs_position_offset,
         )
 
     return (
@@ -591,7 +598,14 @@ def _coadd_slice_inputs(
 
 
 @functools.lru_cache(maxsize=10)
-def _get_gaia_stars(*, fname, wcs, poly_coeffs, radius_factor, max_g_mag):
+def _get_gaia_stars(
+    fname,
+    wcs,
+    wcs_position_offset,
+    poly_coeffs,
+    radius_factor,
+    max_g_mag,
+):
     """
     load the gaia stars
 
@@ -601,6 +615,9 @@ def _get_gaia_stars(*, fname, wcs, poly_coeffs, radius_factor, max_g_mag):
         path to the gaia star catalog
     wcs: WCS object
         The WCS object for the image. Used to calculate x, y
+    wcs_position_offset : int
+        The position offset to get from zero-indexed, pixel-centered
+        coordinates to the coordinates expected by the coadd WCS object.
     poly_coeffs: tuple
         Tuple describing a np.poly1d for log10(radius) vs mag.
         E.g. (0.00443223, -0.22569131, 2.99642999)
@@ -631,6 +648,10 @@ def _get_gaia_stars(*, fname, wcs, poly_coeffs, radius_factor, max_g_mag):
     data['radius_arcsec'] = radius_factor * 10.0**log10_radius_arcsec
 
     data['x'], data['y'] = wcs.sky2image(data['ra'], data['dec'])
+
+    data['x'] -= wcs_position_offset
+    data['y'] -= wcs_position_offset
+
     return data
 
 
@@ -669,14 +690,16 @@ def _intersects(row, col, radius_pixels, nrows, ncols):
 
 
 @njit
-def _do_mask_gaia_stars(rows, cols, radius_pixels, bmask, flag):
+def _do_mask_gaia_stars(rows, cols, radius_pixels, bmask, ormask, flag):
     """
     low level code to mask stars
 
     Parameters
     ----------
     rows, cols: arrays
-        Arrays of rows/cols of star locations; may be off the image
+        Arrays of rows/cols of star locations in the "local" pixel frame of the
+        slice, not the overall pixels of the big coadd. These positions may be
+        off the image
     radius_pixels: float
         The radius for each star mask
     bmask: array
@@ -685,16 +708,34 @@ def _do_mask_gaia_stars(rows, cols, radius_pixels, bmask, flag):
         The flag value to "or" into the bmask
     """
     nrows, ncols = bmask.shape
+    nmasked = 0
 
     for istar in range(rows.size):
         row = rows[istar]
         col = cols[istar]
+
         rad = radius_pixels[istar]
+
+        rowi = int(row)
+        coli = int(col)
+
+        # 226
+        # 2**27
+        if (0 <= rowi < nrows and
+                0 <= coli < ncols and
+                ((ormask[rowi, coli] & 226) != 0)):
+
+            # SATURATE | STAR | TRAIL | EDGEBLEED
+            rad = rad * 1.5
+            # raise ValueError("got one")
+
         rad2 = rad * rad
 
+        # put into local frame for check
         if not _intersects(row, col, rad, nrows, ncols):
             continue
 
+        # these dont in global frame
         for irow in range(nrows):
             rowdiff2 = (row - irow)**2
             for icol in range(ncols):
@@ -702,10 +743,23 @@ def _do_mask_gaia_stars(rows, cols, radius_pixels, bmask, flag):
                 r2 = rowdiff2 + (col - icol)**2
                 if r2 < rad2:
                     bmask[irow, icol] |= flag
+                    nmasked += 1
+
+    return nmasked
 
 
 def _mask_gaia_stars(
-    gaia_stars_file, bmask, wcs, row_cen, col_cen, gaia_mask_config,
+    gaia_stars_file,
+    image,
+    weight,
+    noise,
+    bmask,
+    ormask,
+    wcs,
+    wcs_position_offset,
+    start_row,
+    start_col,
+    gaia_mask_config,
 ):
     """
     mask gaia stars, setting a bit in the bmask
@@ -714,16 +768,18 @@ def _mask_gaia_stars(
     ----------
     gaia_stars_file: str
         Path to the gaia star catalog.  Note the data get cached
-    bmask: array
-        The bmask to modify
+    ormask: array
+        The ormask for the data.  Used to determine if the
+        star in question was saturated
     wcs: WCS object
         The WCS object for the coadd. Used to calculate x, y
-    row_cen: float
-        Center row of the slice in pixels.  Used for calculating the pixel
-        scale
-    col_cen: float
-        Center col of the slice in pixels.  Used for calculating the pixel
-        scale
+    wcs_position_offset : int
+        The position offset to get from zero-indexed, pixel-centered
+        coordinates to the coordinates expected by the coadd WCS object.
+    start_row: int
+        Row in original larger image frame corresponding to row=0
+    start_col: int
+        Column in original larger image frame corresponding to col=0
     gaia_mask_config: dict
         Required fields
             poly_coeffs: sequence
@@ -739,18 +795,41 @@ def _mask_gaia_stars(
 
     # this is cached
     gaia_stars = _get_gaia_stars(
-        fname=gaia_stars_file, wcs=wcs,
+        fname=gaia_stars_file,
+        wcs=wcs,
         poly_coeffs=gaia_mask_config['poly_coeffs'],
         radius_factor=gaia_mask_config['radius_factor'],
         max_g_mag=gaia_mask_config['max_g_mag'],
+        wcs_position_offset=wcs_position_offset,
     )
+
+    row_cen = (start_row + ormask.shape[0]/2)
+    col_cen = (start_col + ormask.shape[1]/2)
 
     pixel_scale = np.sqrt(_compute_wcs_area(wcs, col_cen, row_cen))
     radius_pixels = gaia_stars['radius_arcsec'] / pixel_scale
 
+    gaia_bmask = np.zeros(ormask.shape, dtype=np.int32)
     _do_mask_gaia_stars(
-        rows=gaia_stars['y'],
-        cols=gaia_stars['x'],
+        rows=gaia_stars['y'] - start_row,
+        cols=gaia_stars['x'] - start_col,
         radius_pixels=radius_pixels,
-        bmask=bmask, flag=BMASK_GAIA_STAR,
+        bmask=gaia_bmask,
+        ormask=ormask,
+        flag=BMASK_GAIA_STAR,
     )
+
+    symmetrize_bmask(bmask=gaia_bmask)
+
+    bad_logic = gaia_bmask != 0
+    if np.any(bad_logic):
+
+        bmask |= gaia_bmask
+
+        weight[bad_logic] = 0.0
+
+        interp_image = _grid_interp(image=image, bad_msk=bad_logic, maxfrac=1.0)
+        interp_noise = _grid_interp(image=noise, bad_msk=bad_logic, maxfrac=1.0)
+        return interp_image, interp_noise
+    else:
+        return image, noise

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -29,11 +29,11 @@ from ..._se_image import _compute_wcs_area
 @pytest.fixture(scope="session")
 def coadd_end2end(tmp_path_factory):
     tmp_path = tmp_path_factory.getbasetemp()
-    info, images, weights, bmasks, bkgs, gaia_stars = generate_sim()
+    info, images, weights, bmasks, bkgs, _ = generate_sim()
     write_sim(
         path=tmp_path, info=info,
         images=images, weights=weights, bmasks=bmasks, bkgs=bkgs,
-        gaia_stars=gaia_stars,
+        gaia_stars=None,
     )
 
     with open(os.path.join(tmp_path, 'config.yaml'), 'w') as fp:
@@ -447,29 +447,70 @@ def test_coadding_end2end_weight(coadd_end2end):
     np.allclose(wgt, 1.0 / np.var(nse))
 
 
-def test_coadding_end2end_gaia_stars(coadd_end2end):
+def test_coadding_end2end_gaia_stars(tmp_path_factory):
     """
     make sure pixels are getting masked
     """
-    m = meds.MEDS(coadd_end2end['meds_path'])
-    bmask = m.get_cutout(0, 0, type='bmask')
+    tmp_path = tmp_path_factory.getbasetemp()
+    info, images, weights, bmasks, bkgs, gaia_stars = generate_sim()
+    write_sim(
+        path=tmp_path, info=info,
+        images=images, weights=weights, bmasks=bmasks, bkgs=bkgs,
+        gaia_stars=gaia_stars,
+    )
 
-    if False:
-        import pdb
-        import matplotlib.pyplot as plt
-        fig, axs = plt.subplots(nrows=1, ncols=1)
-        axs.imshow((bmask & BMASK_GAIA_STAR) != 0)
-        pdb.set_trace()
+    with open(os.path.join(tmp_path, 'config.yaml'), 'w') as fp:
+        fp.write(SIM_CONFIG)
+
+    cmd = """\
+    des-pizza-cutter \
+      --config={config} \
+      --info={info} \
+      --output-path={tmp_path} \
+      --log-level=DEBUG \
+      --seed=42
+    """.format(
+        config=os.path.join(tmp_path, 'config.yaml'),
+        info=os.path.join(tmp_path, 'info.yaml'),
+        tmp_path=tmp_path)
+
+    mdir = os.environ.get('MEDS_DIR')
+    try:
+        os.environ['MEDS_DIR'] = 'meds_dir_xyz'
+        cp = subprocess.run(cmd, check=True, shell=True, capture_output=True)
+        stdout = str(cp.stdout, 'utf-8').replace('\\n', '\n')
+        stderr = str(cp.stderr, 'utf-8').replace('\\n', '\n')
+        print('stdout:\n', stdout)
+        print('stderr:\n', stdout)
+    except subprocess.CalledProcessError as err:
+        stdout = str(err.stdout, 'utf-8').replace('\\n', '\n')
+        stderr = str(err.stderr, 'utf-8').replace('\\n', '\n')
+        print('stdout:\n', stdout)
+        print('stderr:\n', stderr)
+        raise
+    finally:
+        if mdir is not None:
+            os.environ['MEDS_DIR'] = mdir
+        else:
+            del os.environ['MEDS_DIR']
+
+    meds_path = os.path.join(
+        tmp_path,
+        'e2e_test_p_config_meds-pizza-slices.fits.fz',
+    )
+
+    m = meds.MEDS(meds_path)
+    bmask = m.get_cutout(0, 0, type='bmask')
+    mfrac = m.get_cutout(0, 0, type='mfrac')
+    weight = m.get_cutout(0, 0, type='weight')
 
     # make sure some are masked
     assert np.any((bmask & BMASK_GAIA_STAR) != 0)
 
-    info = coadd_end2end['info']
     wcs = AffineWCS(**info['affine_wcs_config'])
 
-    config = yaml.load(
-        coadd_end2end['config'], Loader=yaml.SafeLoader,
-    )
+    config = yaml.load(SIM_CONFIG, Loader=yaml.SafeLoader)
+
     gaia_mask_config = config['gaia_star_masks']
     gaia_stars = _get_gaia_stars(
         fname=info['gaia_stars_file'], wcs=wcs,
@@ -482,33 +523,45 @@ def test_coadding_end2end_gaia_stars(coadd_end2end):
     scale = np.sqrt(_compute_wcs_area(wcs, 10, 10))
 
     # check star center is masked
-    # gaia_stars = coadd_end2end['gaia_stars']
+    # the 1.0 are not perfectly preserved in the compression. Only
+    # zeros are perfectly preserved
+    mfrac_tol = 0.001
     for star in gaia_stars:
         x, y = wcs.sky2image(star['ra'], star['dec'])
         ix = int(x)
         iy = int(y)
 
         assert bmask[iy, ix] & BMASK_GAIA_STAR != 0
+        assert weight[iy, ix] == 0.0
+        assert abs(mfrac[iy, ix] - 1.0) < mfrac_tol
 
         ixlow = int(x - star['radius_arcsec']/scale + 2)
         if ixlow < 0:
             ixlow = 0
         assert bmask[iy, ixlow] & BMASK_GAIA_STAR != 0
+        assert weight[iy, ixlow] == 0.0
+        assert abs(mfrac[iy, ixlow] - 1.0) < mfrac_tol
 
         ixhigh = int(x + star['radius_arcsec']/scale - 3)
         if ixhigh > bmask.shape[1] - 1:
             ixhigh = bmask.shape[1] - 1
         assert bmask[iy, ixhigh] & BMASK_GAIA_STAR != 0
+        assert weight[iy, ixhigh] == 0.0
+        assert abs(mfrac[iy, ixhigh] - 1.0) < mfrac_tol
 
         iylow = int(y - star['radius_arcsec']/scale + 2)
         if iylow < 0:
             iylow = 0
         assert bmask[iylow, ix] & BMASK_GAIA_STAR != 0
+        assert weight[iylow, ix] == 0.0
+        assert abs(mfrac[iylow, ix] - 1.0) < mfrac_tol
 
         iyhigh = int(y + star['radius_arcsec']/scale - 3)
         if iyhigh > bmask.shape[1] - 1:
             iyhigh = bmask.shape[1] - 1
         assert bmask[iyhigh, ix] & BMASK_GAIA_STAR != 0
+        assert weight[iyhigh, ix] == 0.0
+        assert abs(mfrac[iyhigh, ix] - 1.0) < mfrac_tol
 
 
 def test_coadding_end2end_range_kwarg(tmp_path_factory):

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -476,6 +476,7 @@ def test_coadding_end2end_gaia_stars(coadd_end2end):
         poly_coeffs=tuple(gaia_mask_config['poly_coeffs']),
         radius_factor=gaia_mask_config['radius_factor'],
         max_g_mag=gaia_mask_config['max_g_mag'],
+        wcs_position_offset=1,
     )
 
     scale = np.sqrt(_compute_wcs_area(wcs, 10, 10))

--- a/pizza_cutter/slice_utils/interpolate.py
+++ b/pizza_cutter/slice_utils/interpolate.py
@@ -104,7 +104,7 @@ def _get_nearby_good_pixels(image, bad_msk, nbad, buff=4):
     return bad_pix, good_pix, good_im, good_ind
 
 
-def _grid_interp(*, image, bad_msk):
+def _grid_interp(*, image, bad_msk, maxfrac=0.90):
     """
     interpolate the bad pixels in an image
 
@@ -114,6 +114,9 @@ def _grid_interp(*, image, bad_msk):
         the pixel data
     bad_msk: array
         boolean array, True means it is a bad pixel
+    maxfrac: float
+        If the fraction of bad pixels is greater than this,
+        None is returned
     """
 
     nrows, ncols = image.shape
@@ -122,7 +125,7 @@ def _grid_interp(*, image, bad_msk):
     nbad = bad_msk.sum()
     bm_frac = nbad/npix
 
-    if bm_frac < 0.90:
+    if bm_frac <= 0.90:
 
         bad_pix, good_pix, good_im, good_ind = \
             _get_nearby_good_pixels(image, bad_msk, nbad)


### PR DESCRIPTION
doesn't pass tests, presumably because the masking is fairly extensive

We need a way to turn on/off gaia stars in the test but I don't yet understand how `@pytest.fixture` works