### PR TITLE
REF make sure interp frac is in 0,1

### DIFF
--- a/pizza_cutter/des_pizza_cutter/_coadd_slices.py
+++ b/pizza_cutter/des_pizza_cutter/_coadd_slices.py
@@ -555,7 +555,11 @@ def _coadd_slice_inputs(
 
         image += (resampled_data['image'] * weight)
         noise += (resampled_data['noise'] * weight)
-        interp_se_frac += (resampled_data['interp_frac'] * weight)
+        # we force the interp fraction to be in [0, 1]
+        # because the lanczos interp doesn't do this natively
+        _mfrac = np.abs(resampled_data['interp_frac'])
+        _mfrac = np.clip(_mfrac, 0.0, 1.0)
+        interp_se_frac += (_mfrac * weight)
 
         # for the PSF, we make sure any NaNs are zero
         msk = ~np.isfinite(resampled_data['psf'])

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -411,6 +411,8 @@ def test_coadding_end2end_mfrac(coadd_end2end):
     assert np.any(mfrac[:, 18:20] > 0.0)
     assert np.any(mfrac[:, 33:35] > 0.0)
     assert np.all(mfrac[0:10, 0:10] == 0.0)
+    assert np.all(mfrac >= 0)
+    assert np.all(mfrac <= 1)
 
 
 def test_coadding_end2end_noise(coadd_end2end):


### PR DESCRIPTION
This PR makes sure the interpolation fraction is always in the range of [0, 1]. It does this by taking an absolute value and then clipping the result before coadding. Lanczos does not force this natively. 