### PR TITLE
REF move to image_id as opposed to file_id

### DIFF
--- a/pizza_cutter/des_pizza_cutter/_load_info.py
+++ b/pizza_cutter/des_pizza_cutter/_load_info.py
@@ -86,7 +86,7 @@ def load_objects_into_info(*, info, verbose=True, skip_se=False):
         info['affine_wcs'] = AffineWCS(**info['affine_wcs_config'])
 
     # this is to keep track where it will be in image info extension
-    info['file_id'] = 0
+    info['image_id'] = 0
 
     # we need tuples for hashing
     if 'image_shape' in info:
@@ -102,7 +102,7 @@ def load_objects_into_info(*, info, verbose=True, skip_se=False):
         _itrbl = enumerate(info['src_info'])
     for index, ii in _itrbl:
         # this is to keep track where it will be in image info extension
-        ii['file_id'] = index+1
+        ii['image_id'] = index+1
 
         # we need tuples for hashing
         if 'image_shape' in ii:

--- a/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
+++ b/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
@@ -654,7 +654,7 @@ def _make_epochs_info(
     """
     dt = [
         ('id', 'i8'),
-        ('file_id', 'i8'),  # index into image info
+        ('image_id', 'i8'),
         ('flags', 'i4'),
         ('row_start', 'i8'),
         ('col_start', 'i8'),
@@ -672,7 +672,7 @@ def _make_epochs_info(
 
     for weight, se_slice in zip(weights, slices):
         data['flags'][loc] = 0  # we used it, so flags are zero
-        data['file_id'][loc] = se_slice.source_info['file_id']
+        data['image_id'][loc] = se_slice.source_info['image_id']
 
         data['row_start'][loc] = se_slice.y_start
         data['col_start'][loc] = se_slice.x_start
@@ -687,7 +687,7 @@ def _make_epochs_info(
 
     for flags, se_slice in zip(flags_not_used, slices_not_used):
         data['flags'][loc] = flags
-        data['file_id'][loc] = se_slice.source_info['file_id']
+        data['image_id'][loc] = se_slice.source_info['image_id']
 
         data['row_start'][loc] = se_slice.y_start
         data['col_start'][loc] = se_slice.x_start
@@ -748,7 +748,8 @@ def _build_object_data(
     # and fill!
     output_info['id'] = np.arange(len(rows))
     output_info['box_size'] = box_size
-    output_info['file_id'] = 0
+    # this is not used here so set to -1
+    output_info['file_id'] = -1
     output_info['psf_box_size'] = psf_box_size
     output_info['psf_cutout_row'] = psf_cen
     output_info['psf_cutout_col'] = psf_cen
@@ -829,7 +830,7 @@ def _build_image_info(*, info):
         ext_len=3)
 
     # first we do the coadd since it is special
-    ii['image_id'][0] = info['file_id']
+    ii['image_id'][0] = info['image_id']
     ii['image_flags'][0] = info['image_flags']
     ii['magzp'][0] = info['magzp']
     ii['scale'][0] = info['scale']
@@ -843,7 +844,7 @@ def _build_image_info(*, info):
                 'image_path', 'image_ext', 'weight_path', 'weight_ext',
                 'bmask_path', 'bmask_ext', 'bkg_path', 'bkg_ext']:
             ii[key][loc] = se_info[key]
-        ii['image_id'][loc] = se_info['file_id']
+        ii['image_id'][loc] = se_info['image_id']
         ii['image_flags'][loc] = se_info['image_flags']
         ii['magzp'][loc] = se_info['magzp']
         ii['scale'][loc] = se_info['scale']
@@ -851,6 +852,8 @@ def _build_image_info(*, info):
         ii['wcs'][loc] = json.dumps(eval(str(
             _noerr_load_image_wcs(se_info)
         )))
+
+    assert np.array_equal(ii["image_id"], np.arange(len(ii), dtype=np.int32))
 
     return ii
 

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -128,25 +128,25 @@ def test_coadding_end2end_epochs_info(coadd_end2end):
     # images 0, 1, 2 do not intersect the slice or get cut before they make
     # it into the epochs_info extensions
     # we add 1 for the file id's
-    assert np.all(ei['file_id'] != 1)
-    assert np.all(ei['file_id'] != 2)
-    assert np.all(ei['file_id'] != 3)
+    assert np.all(ei['image_id'] != 1)
+    assert np.all(ei['image_id'] != 2)
+    assert np.all(ei['image_id'] != 3)
 
     # images 4 is flagged at the pixel level
-    msk = ei['file_id'] == 4
+    msk = ei['image_id'] == 4
     assert np.all((ei['flags'][msk] & SLICE_HAS_FLAGS) != 0)
     assert np.all(ei['weight'][msk] == 0)
 
     # images  6, 7, 8 have too high a masked fraction
-    msk = ei['file_id'] == 6
+    msk = ei['image_id'] == 6
     assert np.all((ei['flags'][msk] & HIGH_MASKED_FRAC) != 0)
     assert np.all(ei['weight'][msk] == 0)
 
-    msk = ei['file_id'] == 7
+    msk = ei['image_id'] == 7
     assert np.all((ei['flags'][msk] & HIGH_MASKED_FRAC) != 0)
     assert np.all(ei['weight'][msk] == 0)
 
-    msk = ei['file_id'] == 8
+    msk = ei['image_id'] == 8
     assert np.all((ei['flags'][msk] & HIGH_MASKED_FRAC) != 0)
     assert np.all(ei['weight'][msk] == 0)
 
@@ -155,7 +155,7 @@ def test_coadding_end2end_epochs_info(coadd_end2end):
     max_wgts = []
     for ind in range(len(ei)):
         if ei['weight'][ind] > 0:
-            src_ind = ei['file_id'][ind]-1
+            src_ind = ei['image_id'][ind]-1
             max_wgts.append(
                 np.max(weights[src_ind]) /
                 info['src_info'][src_ind]['scale'] ** 2
@@ -215,7 +215,7 @@ def test_coadding_end2end_object_data(coadd_end2end):
     max_wgts = []
     for ind in range(len(ei)):
         if ei['weight'][ind] > 0:
-            src_ind = ei['file_id'][ind]-1
+            src_ind = ei['image_id'][ind]-1
             max_wgts.append(
                 np.max(weights[src_ind]) /
                 info['src_info'][src_ind]['scale'] ** 2
@@ -228,7 +228,7 @@ def test_coadding_end2end_object_data(coadd_end2end):
     assert object_data['ra'][0] == 0
     assert object_data['dec'][0] == 0
     assert object_data['ncutout'][0] == 1
-    assert object_data['file_id'][0, 0] == 0
+    assert object_data['file_id'][0, 0] == -1
     assert object_data['cutout_row'][0, 0] == 24
     assert object_data['cutout_col'][0, 0] == 24
 
@@ -262,7 +262,7 @@ def test_coadding_end2end_psf(coadd_end2end):
     psfs = []
     for ind in range(len(ei)):
         if ei['weight'][ind] > 0:
-            src_ind = ei['file_id'][ind]-1
+            src_ind = ei['image_id'][ind]-1
             max_wgts.append(
                 np.max(weights[src_ind]) /
                 info['src_info'][src_ind]['scale'] ** 2
@@ -317,7 +317,7 @@ def test_coadding_end2end_gal(coadd_end2end):
     psfs = []
     for ind in range(len(ei)):
         if ei['weight'][ind] > 0:
-            src_ind = ei['file_id'][ind]-1
+            src_ind = ei['image_id'][ind]-1
             max_wgts.append(
                 np.max(weights[src_ind]) /
                 info['src_info'][src_ind]['scale'] ** 2
@@ -489,7 +489,7 @@ def test_coadding_end2end_noise(coadd_end2end):
     max_wgts = []
     for ind in range(len(ei)):
         if ei['weight'][ind] > 0:
-            src_ind = ei['file_id'][ind]-1
+            src_ind = ei['image_id'][ind]-1
             max_wgts.append(
                 np.max(weights[src_ind]) /
                 info['src_info'][src_ind]['scale'] ** 2
@@ -517,7 +517,7 @@ def test_coadding_end2end_extra_noise_images(coadd_end2end_extra_noise_images):
     max_wgts = []
     for ind in range(len(ei)):
         if ei['weight'][ind] > 0:
-            src_ind = ei['file_id'][ind]-1
+            src_ind = ei['image_id'][ind]-1
             max_wgts.append(
                 np.max(weights[src_ind]) /
                 info['src_info'][src_ind]['scale'] ** 2

--- a/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_image_info.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_image_info.py
@@ -6,14 +6,14 @@ from .._pizza_cutter import _build_image_info
 def test_pizza_cutter_build_image_info():
     info = {
         'image_flags': 10,
-        'file_id': 0,
+        'image_id': 0,
         'magzp': 32,
         'scale': 0.5,
         'position_offset': 3,
         'image_wcs': "{'key1': 'val1'}",
         'src_info': [
             {
-                'file_id': 1,
+                'image_id': 1,
                 'image_path': 'a',
                 'image_ext': 'b',
                 'weight_path': 'c',
@@ -29,7 +29,7 @@ def test_pizza_cutter_build_image_info():
                 'image_wcs': "{'key2': 'val2'}"
             },
             {
-                'file_id': 2,
+                'image_id': 2,
                 'image_path': 'aa',
                 'image_ext': 'bb',
                 'weight_path': 'cc',

--- a/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_object_data.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_object_data.py
@@ -15,7 +15,7 @@ def test_pizza_cutter_build_object_data(coadd_image_data):
 
     assert np.array_equal(d['id'], np.arange(d.shape[0]))
     assert np.all(d['box_size'] == 500)
-    assert np.all(d['file_id'] == 0)
+    assert np.all(d['file_id'] == -1)
     assert np.all(d['psf_box_size'] == 21)
     assert np.all(d['psf_cutout_row'] == 10)
     assert np.all(d['psf_cutout_col'] == 10)


### PR DESCRIPTION
This PR changes from file_id to image_id everywhere and sets the image_ids to always be the same as the index into the image_info. This will make working with the files a lot simpler and more clear. 