### PR TITLE
BUG always return Nones for all bad pixels

### DIFF
--- a/pizza_cutter/slice_utils/interpolate.py
+++ b/pizza_cutter/slice_utils/interpolate.py
@@ -153,7 +153,7 @@ def interpolate_image_at_mask(
 
     nbad = bad_msk.sum()
     bm_frac = nbad/npix
-    if bm_frac <= maxfrac:
+    if bm_frac <= maxfrac and nbad < npix:
         interp_image = image.copy()
 
         bad_ind, bad_iso, _good_ind = _get_nearby_good_pixels(
@@ -294,7 +294,7 @@ def interpolate_image_and_noise(
     if np.any(bad_msk):
         logger.debug('doing image interpolation')
 
-        if np.mean(bad_msk) > maxfrac:
+        if np.mean(bad_msk) > maxfrac or np.all(bad_msk):
             return None, None
 
         med_weight = np.median(weight[~bad_msk])

--- a/pizza_cutter/slice_utils/tests/test_interpolate.py
+++ b/pizza_cutter/slice_utils/tests/test_interpolate.py
@@ -217,8 +217,6 @@ def test_interpolate_image_and_noise_allbad():
 
     rng = np.random.RandomState(seed=42)
     bmask[:, :] = 1
-    bmask[:, 0] = 2
-    bmask[:, -1] = 4
 
     # put nans here to make sure interp is done ok
     msk = (bmask & bad_flags) != 0

--- a/pizza_cutter/slice_utils/tests/test_interpolate.py
+++ b/pizza_cutter/slice_utils/tests/test_interpolate.py
@@ -236,7 +236,7 @@ def test_interpolate_image_and_noise_allbad():
         noises=noises)
 
     assert iimage is None
-    assert all(ins is None for ins in inoises)
+    assert inoises is None
 
 
 def test_interpolate_gauss_image(show=False):

--- a/pizza_cutter/slice_utils/tests/test_interpolate.py
+++ b/pizza_cutter/slice_utils/tests/test_interpolate.py
@@ -236,7 +236,7 @@ def test_interpolate_image_and_noise_allbad():
         noises=noises)
 
     assert iimage is None
-    assert inoises is None
+    assert all(ins is None for ins in inoises)
 
 
 def test_interpolate_gauss_image(show=False):


### PR DESCRIPTION
This PR makes sure the interp functions always return Nones for all bad pixels.

todo:
 - [x] tests of interp functions with all bad pixels