### PR TITLE
BUG only symmetrize the flags we are interpolating and don't symmetrize in GAIA masks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
         run: |
           git clone https://github.com/beckermr/des-y3-test-data.git
           export TEST_DESDATA=`pwd`/des-y3-test-data
-          pytest -vv pizza_cutter
+          pytest -n 2 -vv pizza_cutter

--- a/bin/des-pizza-cutter
+++ b/bin/des-pizza-cutter
@@ -18,7 +18,7 @@ from pizza_cutter.des_pizza_cutter import (
 
 def go(
     config, info, tag, output_path, log_level, seed, slice_range,
-    tmpdir, n_jobs, n_extra_noise_images
+    tmpdir, n_jobs, n_extra_noise_images, n_chunks,
 ):
     """Create a metadetection MEDS file from a DES coadd tile."""
 
@@ -86,6 +86,7 @@ def go(
         coadd_config=cfg['coadd'],
         single_epoch_config=cfg['single_epoch'],
         n_jobs=n_jobs,
+        n_chunks=n_chunks,
         n_extra_noise_images=n_extra_noise_images,
         remove_fits_file=(
             False
@@ -146,10 +147,14 @@ def go(
     '--n-extra-noise-images', type=int, default=0,
     help='the number of extra noise images to produce for each coadd.',
 )
+@click.option(
+    '--n-chunks', type=int, default=None,
+    help='the number of chunks of slices to feed to the multiprocessing jobs.',
+)
 def main(
     config, info, tag, output_path, log_level, seed,
     slice_range,
-    use_tmpdir, tmpdir, n_jobs, n_extra_noise_images,
+    use_tmpdir, tmpdir, n_jobs, n_extra_noise_images, n_chunks,
 ):
     """Create a metadetection MEDS file from a DES coadd tile."""
 
@@ -157,6 +162,7 @@ def main(
         go(
             config, info, tag, output_path, log_level,
             seed, slice_range, _tmpdir, n_jobs, n_extra_noise_images,
+            n_chunks,
         )
 
     if use_tmpdir and tmpdir is None:

--- a/config_files/des-pizza-slices-y6-v10.yaml
+++ b/config_files/des-pizza-slices-y6-v10.yaml
@@ -68,6 +68,8 @@ single_epoch:
   # "STREAK":    1024,  #/* pixel associated with streak from a       */
   #                     #/*       satellite, meteor, ufo...           */
   # "SUSPECT":   2048,  #/* nominally useful pixel but not perfect    */
+  # "FIXED":     4096,  # bad coilumn that DESDM reliably fixes       */
+  # "NEAREDGE":  8192,  #/* marks 25 bad columns neat the edge        */
   # "TAPEBUMP": 16384,  #/* tape bumps                                */
 
   spline_interp_flags:
@@ -90,8 +92,21 @@ single_epoch:
   # star areas are ignored for now - GAIA masks will handle them or star-gal sep
   #  - 32    # STAR
   #  - 2048  # SUSPECT
+  #  - 4096  # FIXED by DESDM reliably
+  #  - 8192  # NEAREDGE 25 bad columns on each edge, removed anyways due to 48 pixel boundry
   #  - 16384 # TAPEBUMP
 
   bad_image_flags:
     # data from non-functional amplifiers is ignored
     - 8     # BADAMP
+
+  gaia_star_masks:
+    poly_coeffs: [1.36055007e-03, -1.55098040e-01,  3.46641671e+00]
+    max_g_mag: 18.0
+    symmetrize: False
+    # interp:
+    #   fill_isolated_with_noise: False
+    #   iso_buff: 1
+    apodize:
+      ap_rad: 1
+    mask_expand_rad: 16

--- a/pizza_cutter/des_pizza_cutter/_coadd_slices.py
+++ b/pizza_cutter/des_pizza_cutter/_coadd_slices.py
@@ -261,11 +261,11 @@ def _build_slice_inputs(
                     se_slice.weight[msk] = 0
 
                     bmask_r = bmask_orig.copy()
-                    symmetrize_bmask(bmask=bmask_r, angle=angle)
+                    symmetrize_bmask(bmask=bmask_r, angle=angle, sym_flags=bad_flags)
                     se_slice.bmask |= bmask_r
             else:
                 # this operates in place on references
-                symmetrize_bmask(bmask=se_slice.bmask)
+                symmetrize_bmask(bmask=se_slice.bmask, sym_flags=bad_flags)
                 symmetrize_weight(weight=se_slice.weight)
 
         if not copy_masked_edges:

--- a/pizza_cutter/des_pizza_cutter/_coadd_slices.py
+++ b/pizza_cutter/des_pizza_cutter/_coadd_slices.py
@@ -103,7 +103,7 @@ def _build_slice_inputs(
         coordinates to the coordinates expected by the coadd WCS object.
     wcs_interp_delta : int
         The spacing to use for the WCS interpolation.
-    gaia_star_mask : np.ndarray
+    gaia_star_mask : np.ndarray, optional
         An array of booleans marking pixels masked by GAIA stars.
     se_src_info : list of dicts
         The 'src_info' entry from the info file.
@@ -116,8 +116,8 @@ def _build_slice_inputs(
         'noise' - use the maximum of the weight map for each SE image.
         'noise-fwhm' - use the maximum of the weight map divided by the
             (PSF FWHM)**4
-    tmpdir: optional, string
-        Optional temporary directory for temporary files
+    tmpdir: str, optional
+        Optional temporary directory for temporary files.
     n_extra_noise_images : int
         The number of extra noise images to make. These are written as cutout
         types 'noise1', 'noise2', etc. in the final MEDS file.
@@ -272,7 +272,7 @@ def _build_slice_inputs(
 
         # if we have a coadd gaia mask, we map it to the SE image and then
         # don't symmetrize stuff in that mask
-        if gaia_star_mask:
+        if gaia_star_mask is not None:
             se_gaia_star_mask = se_slice.map_image_by_nearest_pixel(
                 image=gaia_star_mask,
                 x_start=start_col,
@@ -285,7 +285,7 @@ def _build_slice_inputs(
             se_gaia_star_mask = None
 
         if symmetrize_masking:
-            logger.debug('symmetrizing the masks: var = %s', symmetrize_masking)
+            logger.debug('symmetrizing the masks: config var = %s', symmetrize_masking)
             if isinstance(symmetrize_masking, list):
                 weight_orig = se_slice.weight.copy()
                 bmask_orig = se_slice.bmask.copy()

--- a/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
+++ b/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
@@ -282,7 +282,7 @@ def _coadd_single_slice(
 
     gaia_stars_file = info.get('gaia_stars_file', None)
     if gaia_stars_file is not None and "gaia_star_masks" in single_epoch_config:
-        logger.info("building GAIA star mask for slice")
+        logger.info("\n\n\n\n building GAIA star mask for slice\n\n\n\n\n\n\n\n")
         gaia_stars = _read_gaia_stars(
             fname=gaia_stars_file,
             wcs=wcs,

--- a/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
+++ b/pizza_cutter/des_pizza_cutter/_pizza_cutter.py
@@ -282,7 +282,7 @@ def _coadd_single_slice(
 
     gaia_stars_file = info.get('gaia_stars_file', None)
     if gaia_stars_file is not None and "gaia_star_masks" in single_epoch_config:
-        logger.info("\n\n\n\n building GAIA star mask for slice\n\n\n\n\n\n\n\n")
+        logger.info("building GAIA star mask for slice %d", i)
         gaia_stars = _read_gaia_stars(
             fname=gaia_stars_file,
             wcs=wcs,

--- a/pizza_cutter/des_pizza_cutter/_se_image.py
+++ b/pizza_cutter/des_pizza_cutter/_se_image.py
@@ -1173,8 +1173,8 @@ class SEImageSlice(object):
         x_img, y_img = wcs_interp(x_self, y_self)
         x_img -= x_start
         y_img -= y_start
-        y_img = (y_img + 0.5).astype(np.int64)
-        x_img = (x_img + 0.5).astype(np.int64)
+        y_img = np.floor(y_img + 0.5).astype(np.int64)
+        x_img = np.floor(x_img + 0.5).astype(np.int64)
         msk = (
             (x_img >= 0)
             & (x_img < image.shape[1])

--- a/pizza_cutter/des_pizza_cutter/_se_image.py
+++ b/pizza_cutter/des_pizza_cutter/_se_image.py
@@ -160,7 +160,10 @@ def _get_wcs_inverse(wcs, wcs_position_offset, se_wcs, se_im_shape, delta):
     x_coadd -= wcs_position_offset
     y_coadd -= wcs_position_offset
 
-    return WCSInversionInterpolator(x_coadd, y_coadd, x_se, y_se)
+    return (
+        WCSInversionInterpolator(x_coadd, y_coadd, x_se, y_se),
+        WCSInversionInterpolator(x_se, y_se, x_coadd, y_coadd),
+    )
 
 
 def _compute_wcs_area(se_wcs, x_se, y_se, dxy=1):
@@ -1104,7 +1107,8 @@ class SEImageSlice(object):
         interp_noises : list of np.ndarray
             The interpolated noise fields.
         mask : np.ndarray
-            An array of ints w/ the same shape as the image.
+            An array of ints w/ the same shape as the image indicating where
+            interpolation was done.
         """
         msk = mask != 0
 
@@ -1117,6 +1121,68 @@ class SEImageSlice(object):
         self.image = interp_image
         self.noises = interp_noises
         self.pmask = mask
+
+    def map_image_by_nearest_pixel(
+        self,
+        *,
+        image, x_start, y_start,
+        wcs,
+        wcs_position_offset,
+        wcs_interp_delta
+    ):
+        """Map an image to the slice using the nearest pixel.
+
+        NOTE: Typically, the input WCS object will be for a coadd.
+
+        Parameters
+        ----------
+        image : np.ndarray
+            The image to be mapped to the SE slice.
+        x_start : int
+            The zero-indexed, pixel-centered starting x/column of the input image.
+        y_start : int
+            The zero-indexed, pixel-centered starting y/row of the input image.
+        wcs : `esutil.wcsutil.WCS` or `AffineWCS` object
+            The WCS model to use for the input image. This object is
+            assumed to take one-indexed, pixel-centered coordinates.
+        wcs_position_offset : int
+            The coordinate offset, if any, to get from the zero-indexed, pixel-
+            centered coordinates used by this class to the coordinate convetion
+            of the input `wcs` object.
+        wcs_interp_delta : int
+            The spacing in pixels used for interpolating the WCS transforms.
+        """
+        if not hasattr(self, 'box_size'):
+            raise RuntimeError("You must call set_slice before mapping images!")
+
+        mapped_image = np.zeros((self.box_size, self.box_size), dtype=image.dtype)
+
+        t0 = time.time()
+        _, wcs_interp = _get_wcs_inverse(
+            wcs, wcs_position_offset,
+            self,
+            self._im_shape,
+            wcs_interp_delta)
+        if hasattr(_get_wcs_inverse, "cache_info"):
+            logger.debug('wcs interp cache info: %s', _get_wcs_inverse.cache_info())
+        logger.debug('wcs interp took %f seconds', time.time() - t0)
+
+        y_self, x_self = np.mgrid[0:self.box_size, 0:self.box_size]
+        x_self = x_self.ravel() + self.x_start
+        y_self = y_self.ravel() + self.y_start
+        x_img, y_img = wcs_interp(x_self, y_self)
+        x_img -= x_start
+        y_img -= y_start
+        y_img = (y_img + 0.5).astype(np.int64)
+        x_img = (x_img + 0.5).astype(np.int64)
+        msk = (
+            (x_img >= 0)
+            & (x_img < image.shape[1])
+            & (y_img >= 0)
+            & (y_img < image.shape[0])
+        )
+        mapped_image[y_self[msk], x_self[msk]] = image[y_img[msk], x_img[msk]]
+        return mapped_image
 
     def resample(
         self, *, wcs, wcs_position_offset, wcs_interp_shape,
@@ -1203,7 +1269,7 @@ class SEImageSlice(object):
         # terms which require a root finder
         # we use a buffer to make sure edge pixels are ok
         t0 = time.time()
-        wcs_interp = _get_wcs_inverse(
+        wcs_interp, _ = _get_wcs_inverse(
             wcs, wcs_position_offset,
             self,
             self._im_shape,

--- a/pizza_cutter/des_pizza_cutter/_se_image.py
+++ b/pizza_cutter/des_pizza_cutter/_se_image.py
@@ -1181,7 +1181,10 @@ class SEImageSlice(object):
             & (y_img >= 0)
             & (y_img < image.shape[0])
         )
-        mapped_image[y_self[msk], x_self[msk]] = image[y_img[msk], x_img[msk]]
+        mapped_image[
+            y_self[msk] - self.y_start,
+            x_self[msk] - self.x_start
+        ] = image[y_img[msk], x_img[msk]]
         return mapped_image
 
     def resample(

--- a/pizza_cutter/des_pizza_cutter/integration_test/data.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/data.py
@@ -136,6 +136,59 @@ single_epoch:
 """
 
 
+SIM_CONFIG_GAIA = """\
+fpack_pars:
+  FZQVALUE: 4
+  FZTILE: "(10240,1)"
+  FZALGOR: "RICE_1"
+  # preserve zeros, don't dither them
+  FZQMETHD: "SUBTRACTIVE_DITHER_2"
+
+coadd:
+  # these are in pixels
+  # the total "pizza slice" will be central_size + 2 * buffer_size
+  central_size: 33  # size of the central region
+  buffer_size: 8  # size of the buffer on each size
+
+  psf_box_size: 51
+
+  wcs_type: affine
+  coadding_weight: 'noise'
+
+single_epoch:
+  # pixel spacing for building various WCS interpolants
+  se_wcs_interp_delta: 8
+  coadd_wcs_interp_delta: 8
+
+  frac_buffer: 1
+  psf_type: galsim
+  wcs_type: affine
+  wcs_color: 0
+
+  reject_outliers: False
+  symmetrize_masking: True
+  copy_masked_edges: False
+  max_masked_fraction: 0.1
+  edge_buffer: 8
+
+  mask_tape_bumps: False
+
+  spline_interp_flags:
+    - 2
+
+  noise_interp_flags:
+    - 4
+
+  bad_image_flags:
+    - 1
+
+  gaia_star_masks:
+    poly_coeffs: [1.4e-03, -1.6e-01,  3.5e+00]
+    max_g_mag: 18.0
+    symmetrize: False
+"""
+
+
 def write_sim(
     *, path, info, images, weights, bmasks, bkgs, gaia_stars=None,
 ):

--- a/pizza_cutter/des_pizza_cutter/integration_test/data.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/data.py
@@ -486,7 +486,13 @@ def generate_gaia_stars(rng, image_shape, num, wcs):
     wcs: galsim wcs
         Must have image2sky method
     """
-    dt = [('ra', 'f8'), ('dec', 'f8'), ('phot_g_mean_mag', 'f4')]
+    dt = [
+        ('ra', 'f8'),
+        ('dec', 'f8'),
+        ('phot_g_mean_mag', 'f4'),
+        ('xgen', 'f8'),
+        ('ygen', 'f8'),
+    ]
     data = np.zeros(num, dtype=dt)
 
     # fairly small radii
@@ -494,6 +500,8 @@ def generate_gaia_stars(rng, image_shape, num, wcs):
 
     rows = rng.uniform(low=10, high=image_shape[0]-10-1, size=num)
     cols = rng.uniform(low=10, high=image_shape[1]-10-1, size=num)
+    data['xgen'] = cols
+    data['ygen'] = rows
 
     data['ra'], data['dec'] = wcs.image2sky(cols, rows)
     return data

--- a/pizza_cutter/des_pizza_cutter/integration_test/data.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/data.py
@@ -85,17 +85,6 @@ single_epoch:
 
   bad_image_flags:
     - 1
-
-gaia_star_masks:
-  # multiply the radii by this factor
-  radius_factor: 1.0
-
-  # don't mask stars with gaia g mag less than this
-  max_g_mag: 18.0
-
-  # coefficients for log10(radius) vs mag.  Don't change this unless
-  # you know what you are doing
-  poly_coeffs: [0.00443223, -0.22569131, 2.99642999]
 """
 
 
@@ -144,17 +133,6 @@ single_epoch:
 
   bad_image_flags:
     - 1
-
-gaia_star_masks:
-  # multiply the radii by this factor
-  radius_factor: 1.0
-
-  # don't mask stars with gaia g mag less than this
-  max_g_mag: 18.0
-
-  # coefficients for log10(radius) vs mag.  Don't change this unless
-  # you know what you are doing
-  poly_coeffs: [0.00443223, -0.22569131, 2.99642999]
 """
 
 

--- a/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
+++ b/pizza_cutter/des_pizza_cutter/integration_test/tests/test_coadding_end2end.py
@@ -125,8 +125,6 @@ def test_coadding_end2end_epochs_info(coadd_end2end):
     info = coadd_end2end['info']
     m = meds.MEDS(coadd_end2end['meds_path'])
 
-    assert GAIA_STARS_EXTNAME not in m._fits
-
     ei = m._fits['epochs_info'].read()
 
     ############################################################

--- a/pizza_cutter/des_pizza_cutter/tests/test_piff_tools.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_piff_tools.py
@@ -4,6 +4,7 @@ import pytest
 from .._piff_tools import compute_piff_flags, get_piff_psf_info
 
 
+@pytest.mark.xfail()
 @pytest.mark.skipif(
     not os.path.exists(os.path.expanduser("~/.desservices.ini")),
     reason="no DESDM access",

--- a/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_gaia_stars.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_pizza_cutter_gaia_stars.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+import pytest
+
+from .._pizza_cutter import _build_gaia_star_mask
+
+
+@pytest.mark.parametrize("symmetrize", [True, False])
+def test_build_gaia_star_mask(symmetrize):
+    gaia_stars = np.array(
+        [(20, 10, 19.5), (39, 29, 20.1)],
+        dtype=[
+            ("x", "f8"),
+            ("y", "f8"),
+            ("phot_g_mean_mag", "f8"),
+        ],
+    )
+
+    rad = 10.0**(np.poly1d([1.5e-3, -1.6e-01,  3.5e+00])(19.5))
+    sarea = np.pi*rad**2/4
+    if symmetrize:
+        sarea *= 2
+    area_frac = sarea / 400.0
+
+    gmask = _build_gaia_star_mask(
+        gaia_stars=gaia_stars,
+        max_g_mag=20,
+        poly_coeffs=[1.5e-3, -1.6e-01,  3.5e+00],
+        start_col=20,
+        start_row=10,
+        box_size=20,
+        symmetrize=symmetrize,
+    )
+    assert gmask[0, 0]
+    assert not gmask[-1, -1]
+    if symmetrize:
+        assert gmask[-1, 0]
+    else:
+        assert not gmask[-1, 0]
+    assert np.allclose(np.mean(gmask), area_frac, rtol=0, atol=4e-2)

--- a/pizza_cutter/des_pizza_cutter/tests/test_se_image_map_image.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_se_image_map_image.py
@@ -1,0 +1,73 @@
+import os
+import numpy as np
+import pytest
+
+import piff
+from meds.bounds import Bounds
+
+from .._se_image import SEImageSlice
+
+
+@pytest.mark.skipif(
+    os.environ.get('TEST_DESDATA', None) is None,
+    reason=(
+        'SEImageSlice can only be tested if '
+        'test data is at TEST_DESDATA'))
+def test_se_image_map_image(se_image_data, coadd_image_data):
+    psf_mod = piff.PSF.read(se_image_data['source_info']['piff_path'])
+    se_im = SEImageSlice(
+        source_info=se_image_data['source_info'],
+        psf_model=psf_mod,
+        wcs=se_image_data['eu_wcs'],
+        wcs_position_offset=1,
+        wcs_color=0,
+        noise_seeds=[10, 11, 23, 45],
+        mask_tape_bumps=False,
+    )
+    se_im._im_shape = (512, 512)
+    dim = 10
+    half = 5
+    ra, dec = se_im.image2sky(300, 150)
+    patch_bnds = Bounds(
+        rowmin=150-half,
+        rowmax=150-half+dim-1,
+        colmin=300-half,
+        colmax=300-half+dim-1,
+    )
+    se_im.set_slice(patch_bnds)
+    se_im.set_psf(ra, dec)
+    se_im.set_interp_image_noise_pmask(
+        interp_image=se_im.image,
+        interp_noises=se_im.noises,
+        mask=np.zeros_like(se_im.bmask),
+    )
+    x, y = coadd_image_data['eu_wcs'].sky2image(ra, dec)
+    x = int(np.floor(x+0.5)) - coadd_image_data['position_offset']
+    y = int(np.floor(y+0.5)) - coadd_image_data['position_offset']
+    x_start = x - half*2
+    y_start = y - half*2
+    coadd_img = np.arange(dim*2*dim*2).reshape(2*dim, 2*dim)
+    res = se_im.map_image_by_nearest_pixel(
+        image=coadd_img,
+        wcs=coadd_image_data['eu_wcs'],
+        wcs_position_offset=coadd_image_data['position_offset'],
+        x_start=x_start,
+        y_start=y_start,
+        wcs_interp_delta=8,
+    )
+    assert np.all(np.isfinite(res))
+
+    for row in range(res.shape[0]):
+        for col in range(res.shape[1]):
+            y = row + se_im.y_start
+            x = col + se_im.x_start
+            ra, dec = se_im.image2sky(x, y)
+            xc, yc = coadd_image_data['eu_wcs'].sky2image(ra, dec)
+            xc -= coadd_image_data['position_offset']
+            yc -= coadd_image_data['position_offset']
+            xc = int(np.floor(xc+0.5)) - x_start
+            yc = int(np.floor(yc+0.5)) - y_start
+            if yc >= 0 and yc < 2*dim and xc >= 0 and xc < 2*dim:
+                assert coadd_img[yc, xc] == res[row, col]
+            else:
+                assert 0 == res[row, col]

--- a/pizza_cutter/des_pizza_cutter/tests/test_se_image_wcs_inverse.py
+++ b/pizza_cutter/des_pizza_cutter/tests/test_se_image_wcs_inverse.py
@@ -106,7 +106,7 @@ def test_se_image_get_wcs_inverse_pixmappy(se_image_data, coadd_image_data):
         se_wcs,
         (SE_DIMS_CUT, SE_DIMS_CUT),
         8,
-    )
+    )[0]
     assert _get_wcs_inverse.cache_info().hits == 0
     wcs_inv = _get_wcs_inverse(
         coadd_wcs,
@@ -114,7 +114,7 @@ def test_se_image_get_wcs_inverse_pixmappy(se_image_data, coadd_image_data):
         se_wcs,
         (SE_DIMS_CUT, SE_DIMS_CUT),
         8,
-    )
+    )[0]
     assert _get_wcs_inverse.cache_info().hits == 1
 
     rng = np.random.RandomState(seed=100)
@@ -183,7 +183,7 @@ def test_se_image_get_wcs_inverse_scamp(se_image_data, coadd_image_data):
         se_wcs,
         (SE_DIMS_CUT, SE_DIMS_CUT),
         8,
-    )
+    )[0]
 
     rng = np.random.RandomState(seed=100)
 

--- a/pizza_cutter/slice_utils/flag.py
+++ b/pizza_cutter/slice_utils/flag.py
@@ -50,7 +50,7 @@ def slice_has_flags(*, bmask, flags):
     return np.any((bmask & flags) != 0)
 
 
-def compute_masked_fraction(*, weight, bmask, bad_flags):
+def compute_masked_fraction(*, weight, bmask, bad_flags, ignore_mask=None):
     """Compute the fraction of an image that is masked.
 
     Parameters
@@ -61,10 +61,22 @@ def compute_masked_fraction(*, weight, bmask, bad_flags):
         The bit mask for the slice.
     bad_flags : int
         The flags to test in the bit mask using `(bmask & bad_flags) != 0`.
+    ignore_mask : array-like, optional
+        If not None, then the masked fraction is computed from only pixels
+        marked as False in this mask.
 
     Returns
     -------
     masked : float
         The fraction masked.
     """
-    return np.mean((weight <= 0.0) | ((bmask & bad_flags) != 0))
+    if ignore_mask is not None:
+        keep_mask = ~ignore_mask
+        if not np.any(keep_mask):
+            return 1.0
+        else:
+            return np.sum(
+                ((weight <= 0.0) | ((bmask & bad_flags) != 0)) & keep_mask
+            ) / np.sum(keep_mask)
+    else:
+        return np.mean((weight <= 0.0) | ((bmask & bad_flags) != 0))

--- a/pizza_cutter/slice_utils/flag.py
+++ b/pizza_cutter/slice_utils/flag.py
@@ -71,10 +71,10 @@ def compute_masked_fraction(*, weight, bmask, bad_flags, ignore_mask=None):
         The fraction masked.
     """
     if ignore_mask is not None:
-        keep_mask = ~ignore_mask
-        if not np.any(keep_mask):
+        if np.all(ignore_mask):
             return 1.0
         else:
+            keep_mask = ~ignore_mask
             return np.sum(
                 ((weight <= 0.0) | ((bmask & bad_flags) != 0)) & keep_mask
             ) / np.sum(keep_mask)

--- a/pizza_cutter/slice_utils/symmetrize.py
+++ b/pizza_cutter/slice_utils/symmetrize.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.ndimage
 
 
-def symmetrize_weight(*, weight, angle=None):
+def symmetrize_weight(*, weight, angle=None, no_sym_mask=None):
     """Symmetrize zero weight pixels.
 
     WARNING: This function operates in-place!
@@ -11,21 +11,30 @@ def symmetrize_weight(*, weight, angle=None):
     ----------
     weight : array-like
         The weight map for the slice.
-    angle : float
+    angle : float, optional
         If not None, then the routine `scipy.ndimage.rotate` is used for the mask
         symmetrization with this angle in degrees. Note that specifying 90 degress
         will not produce the same output as specifying None.
+    no_sym_mask : np.ndarray, optional
+        If passed, only zero-weight pixels at locations where this mask is False will be
+        symmetrized.
     """
     if weight.shape[0] != weight.shape[1]:
         raise ValueError("Only square images can be symmetrized!")
 
+    if no_sym_mask is None:
+        mask = np.ones_like(weight).astype(bool)
+    else:
+        mask = ~no_sym_mask
+
     if angle is None:
+        mask = np.rot90(mask)
         weight_rot = np.rot90(weight)
-        msk = weight_rot == 0.0
+        msk = (weight_rot == 0.0) & mask
         if np.any(msk):
             weight[msk] = 0.0
     else:
-        msk = weight == 0.0
+        msk = (weight == 0.0) & mask
         if np.any(msk):
             rot_wgt = np.zeros_like(weight)
             rot_wgt[msk] = 1.0
@@ -42,7 +51,7 @@ def symmetrize_weight(*, weight, angle=None):
                 weight[msk] = 0.0
 
 
-def symmetrize_bmask(*, bmask, angle=None):
+def symmetrize_bmask(*, bmask, angle=None, no_sym_mask=None, sym_flags=None):
     """Symmetrize masked pixels.
 
     WARNING: This function operates in-place!
@@ -55,16 +64,41 @@ def symmetrize_bmask(*, bmask, angle=None):
         If not None, then the routine `scipy.ndimage.rotate` is used for the mask
         symmetrization with this angle in degrees. Note that specifying 90 degress
         will not produce the same output as specifying None.
+    no_sym_mask : np.ndarray, optional
+        If passed, only bmask pixels at locations where this mask is False will be
+        symmetrized.
+    sym_flags : int, optional
+        If specified, symmetrize only these flags. Otherwise symmetrize all of them.
     """
     if bmask.shape[0] != bmask.shape[1]:
         raise ValueError("Only square images can be symmetrized!")
 
     if angle is None:
-        bmask |= np.rot90(bmask)
+        if no_sym_mask is not None:
+            # if we are not symmetrizing a given pixel, we set its flags to zero
+            # before we apply a rotation
+            bmask_keep = bmask.copy()
+            bmask_keep[no_sym_mask] = 0
+        else:
+            bmask_keep = bmask
+
+        if sym_flags is not None:
+            bmask |= np.rot90(bmask_keep & sym_flags)
+        else:
+            bmask |= np.rot90(bmask_keep)
     else:
+        if no_sym_mask is not None:
+            mask = ~no_sym_mask
+
         for i in range(32):
             bit = 2**i
+            if sym_flags is not None and ((bit & sym_flags) == 0):
+                continue
+
             msk = (bmask & bit) != 0
+            if no_sym_mask is not None:
+                msk &= mask
+
             if np.any(msk):
                 mask_for_bit = np.zeros_like(bmask, dtype=np.float32)
                 mask_for_bit[msk] = 1.0

--- a/pizza_cutter/slice_utils/tests/test_flag.py
+++ b/pizza_cutter/slice_utils/tests/test_flag.py
@@ -100,3 +100,24 @@ def test_compute_masked_fraction_ignore_mask():
         bad_flags=bad_flags,
         ignore_mask=ignore_mask
     ) == 2/99
+
+
+def test_compute_masked_fraction_ignore_mask_all():
+    weight = np.ones((10, 10))
+    bmask = np.zeros((10, 10), dtype=np.int32)
+    bad_flags = 2**0
+
+    weight[4, 7] = 0.0
+    bmask[7, 9] = 4  # try a different flag
+    bmask[8, 2] = 2**0
+    bmask[3, 3] = 2**0
+
+    ignore_mask = np.zeros_like(bmask).astype(bool)
+    ignore_mask[:, :] = 1
+
+    assert compute_masked_fraction(
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        ignore_mask=ignore_mask
+    ) == 1.0

--- a/pizza_cutter/slice_utils/tests/test_flag.py
+++ b/pizza_cutter/slice_utils/tests/test_flag.py
@@ -79,3 +79,24 @@ def test_slice_has_flags():
 
     bmask[6, 6] = 2**0
     assert slice_has_flags(bmask=bmask, flags=flags)
+
+
+def test_compute_masked_fraction_ignore_mask():
+    weight = np.ones((10, 10))
+    bmask = np.zeros((10, 10), dtype=np.int32)
+    bad_flags = 2**0
+
+    weight[4, 7] = 0.0
+    bmask[7, 9] = 4  # try a different flag
+    bmask[8, 2] = 2**0
+    bmask[3, 3] = 2**0
+
+    ignore_mask = np.zeros_like(bmask).astype(bool)
+    ignore_mask[3, 3] = 1
+
+    assert compute_masked_fraction(
+        weight=weight,
+        bmask=bmask,
+        bad_flags=bad_flags,
+        ignore_mask=ignore_mask
+    ) == 2/99

--- a/pizza_cutter/slice_utils/tests/test_symmetrize.py
+++ b/pizza_cutter/slice_utils/tests/test_symmetrize.py
@@ -14,6 +14,19 @@ def test_symmetrize_weight():
     assert np.all(weight[-1, :] == 0)
 
 
+def test_symmetrize_weight_no_sym_mask():
+    weight = np.ones((5, 5))
+    weight[:, 0] = 0
+    mask = np.ones_like(weight).astype(bool)
+    mask[3:5, 0] = False
+    mask = ~mask
+    symmetrize_weight(weight=weight, no_sym_mask=mask)
+
+    assert np.all(weight[:, 0] == 0)
+    assert np.all(weight[-1, :3] == 0)
+    assert np.all(weight[-1, 3:] == 1)
+
+
 def test_symmetrize_weight_angle():
     weight = np.ones((64, 64))
     weight[:, 0] = 0
@@ -44,6 +57,33 @@ def test_symmetrize_weight_angle():
         pdb.set_trace()
 
 
+def test_symmetrize_weight_angle_no_sym_mask():
+    weight = np.ones((64, 64))
+    weight[:, 0] = 0
+    weight_orig = weight.copy()
+
+    mask = np.ones_like(weight).astype(bool)
+    mask[55:, 0] = False
+    mask = ~mask
+
+    for angle in [90, 180, 270]:
+        weight_r = weight_orig.copy()
+        symmetrize_weight(weight=weight_r, angle=angle, no_sym_mask=mask)
+        assert np.all(weight_r[:, 0] == 0)
+        if angle == 90:
+            assert np.all(weight_r[-1, :55] == 0)
+            assert np.all(weight_r[-1, 55:] == 1)
+        elif angle == 180:
+            assert np.all(weight_r[-55:, -1] == 0)
+            assert np.all(weight_r[:-55, -1] == 1)
+        elif angle == 270:
+            assert np.all(weight_r[0, -55:] == 0)
+            # this test overalps with index [0, 0] that was weight zero start with
+            assert np.all(weight_r[0, 1:-55] == 1)
+        else:
+            assert False, "missed an assert!"
+
+
 def test_symmetrize_bmask():
     bmask = np.zeros((4, 4), dtype=np.int32)
     bmask[:, 0] = 1
@@ -56,6 +96,74 @@ def test_symmetrize_bmask():
          [3, 2, 2, 2],
          [1, 0, 2, 0],
          [1, 1, 3, 1]])
+
+
+def test_symmetrize_bmask_sym_flags():
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+    bmask[0, -1] = 2**9
+    symflags = (2**0) | (2**1)
+    symmetrize_bmask(bmask=bmask, sym_flags=symflags)
+
+    assert np.array_equal(
+        bmask,
+        [[1, 0, 2, 2**9],
+         [3, 2, 2, 2],
+         [1, 0, 2, 0],
+         [1, 1, 3, 1]])
+
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+    bmask[0, -1] = 2**9
+    symmetrize_bmask(bmask=bmask)
+
+    assert np.array_equal(
+        bmask,
+        [[1 | 2**9, 0, 2, 2**9],
+         [3, 2, 2, 2],
+         [1, 0, 2, 0],
+         [1, 1, 3, 1]])
+
+
+def test_symmetrize_bmask_no_sym_mask():
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+    mask = np.ones_like(bmask).astype(bool)
+    mask[2:4, 0] = False
+    mask = ~mask
+
+    symmetrize_bmask(bmask=bmask, no_sym_mask=mask)
+
+    assert np.array_equal(
+        bmask,
+        [[1, 0, 2, 0],
+         [3, 2, 2, 2],
+         [1, 0, 2, 0],
+         [1, 1, 2, 0]])
+
+
+def test_symmetrize_bmask_no_sym_mask_sym_flags():
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+    bmask[0, -1] = 2**9
+    symflags = (2**0) | (2**1)
+
+    mask = np.ones_like(bmask).astype(bool)
+    mask[2:4, 0] = False
+    mask = ~mask
+
+    symmetrize_bmask(bmask=bmask, no_sym_mask=mask, sym_flags=symflags)
+
+    assert np.array_equal(
+        bmask,
+        [[1, 0, 2, 2**9],
+         [3, 2, 2, 2],
+         [1, 0, 2, 0],
+         [1, 1, 2, 0]])
 
 
 def test_symmetrize_bmask_angle():
@@ -86,3 +194,123 @@ def test_symmetrize_bmask_angle():
             ax.set_aspect(1)
         import pdb
         pdb.set_trace()
+
+
+def test_symmetrize_bmask_angle_no_sym_mask_sym_flags():
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+    bmask[0, -1] = 2**9
+    symflags = (2**0) | (2**1)
+
+    mask = np.ones_like(bmask).astype(bool)
+    mask[2:4, 0] = False
+    mask = ~mask
+
+    for angle in [90, 180, 270]:
+        bmask_r = bmask.copy()
+        symmetrize_bmask(
+            bmask=bmask_r,
+            angle=angle,
+            no_sym_mask=mask,
+            sym_flags=symflags,
+        )
+        if angle == 90:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 0, 2, 2**9],
+                 [3, 2, 2, 2],
+                 [1, 0, 2, 0],
+                 [1, 1, 2, 0]])
+        elif angle == 180:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 2, 2, 2**9],
+                 [1, 2, 2, 0],
+                 [1, 2, 2, 1],
+                 [1, 2, 2, 1]])
+        elif angle == 270:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 0, 3, 1 | 2**9],
+                 [1, 0, 2, 0],
+                 [3, 2, 2, 2],
+                 [1, 0, 2, 0]])
+        else:
+            assert False, "missed an assert!"
+
+
+def test_symmetrize_bmask_angle_no_sym_mask():
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+
+    mask = np.ones_like(bmask).astype(bool)
+    mask[2:4, 0] = False
+    mask = ~mask
+
+    for angle in [90, 180, 270]:
+        bmask_r = bmask.copy()
+        symmetrize_bmask(bmask=bmask_r, angle=angle, no_sym_mask=mask)
+        if angle == 90:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 0, 2, 0],
+                 [3, 2, 2, 2],
+                 [1, 0, 2, 0],
+                 [1, 1, 2, 0]])
+        elif angle == 180:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 2, 2, 0],
+                 [1, 2, 2, 0],
+                 [1, 2, 2, 1],
+                 [1, 2, 2, 1]])
+        elif angle == 270:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 0, 3, 1],
+                 [1, 0, 2, 0],
+                 [3, 2, 2, 2],
+                 [1, 0, 2, 0]])
+        else:
+            assert False, "missed an assert!"
+
+
+def test_symmetrize_bmask_angle_sym_flags():
+    bmask = np.zeros((4, 4), dtype=np.int32)
+    bmask[:, 0] = 1
+    bmask[:, -2] = 2
+    bmask[0, -1] = 2**9
+    symflags = (2**0) | (2**1)
+
+    for angle in [90, 180, 270]:
+        bmask_r = bmask.copy()
+        symmetrize_bmask(
+            bmask=bmask_r,
+            angle=angle,
+            sym_flags=symflags,
+        )
+        if angle == 90:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 0, 2, 2**9],
+                 [3, 2, 2, 2],
+                 [1, 0, 2, 0],
+                 [1, 1, 3, 1]])
+        elif angle == 180:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 2, 2, 1 | 2**9],
+                 [1, 2, 2, 1],
+                 [1, 2, 2, 1],
+                 [1, 2, 2, 1]])
+        elif angle == 270:
+            assert np.array_equal(
+                bmask_r,
+                [[1, 1, 3, 1 | 2**9],
+                 [1, 0, 2, 0],
+                 [3, 2, 2, 2],
+                 [1, 0, 2, 0]])
+        else:
+            assert False, "missed an assert!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ setuptools_scm
 setuptools_scm_git_archive
 importlib_metadata
 hilbertcurve
+metadetect>=0.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ esutil
 sep
 joblib
 jinja2
-tqdm
 piff
 cfitsio
 setuptools_scm


### PR DESCRIPTION
This PR makes sure we only symmetrize flags we are interpolating or otherwise dealing with. 

It also makes sure we only do this outside of regions we know we will mask. 

closes #271 

to do:
 - [x] write integration test with gaia stars in it
 - [x] test method on SE slice object for mapping coadd images to SE images via nearest pixel