### PR TITLE
ENH add new config with updated GI color

### DIFF
--- a/config_files/des-pizza-slices-y6-v13.yaml
+++ b/config_files/des-pizza-slices-y6-v13.yaml
@@ -1,7 +1,7 @@
 des_data:
   campaign: Y6A2_COADD
   source_type: finalcut
-  piff_campaign: Y6A2_PIFF
+  piff_campaign: Y6A2_PIFF_V2
 
 # optional but these are good defaults
 fpack_pars:

--- a/config_files/des-pizza-slices-y6-v13.yaml
+++ b/config_files/des-pizza-slices-y6-v13.yaml
@@ -1,0 +1,132 @@
+des_data:
+  campaign: Y6A2_COADD
+  source_type: finalcut
+  piff_campaign: Y6A2_PIFF
+
+# optional but these are good defaults
+fpack_pars:
+  # if you do not set FZTILE, the code sets it to the size of a slice for you
+  FZQVALUE: 4
+  FZALGOR: "RICE_1"
+  # preserve zeros, don't dither them
+  FZQMETHD: "SUBTRACTIVE_DITHER_2"
+  # do dithering via a checksum
+  FZDTHRSD: "CHECKSUM"
+
+coadd:
+  # these are in pixels
+  # the total "pizza slice" will be central_size + 2 * buffer_size
+  central_size: 100  # size of the central region
+  buffer_size: 50  # size of the buffer on each size
+
+  # this should be odd and bigger than any stamp returned by the
+  # PSF reconstruction
+  psf_box_size: 51
+
+  wcs_type: image
+  coadding_weight: 'noise'
+
+single_epoch:
+  # pixel spacing for building various WCS interpolants
+  se_wcs_interp_delta: 8
+  coadd_wcs_interp_delta: 100
+
+  # fractional amount to increase coadd box size when getting SE region for
+  # coadding - set to sqrt(2) for full position angle rotations
+  frac_buffer: 1
+
+  # set this to either piff or psfex
+  # if using piff in DES and a release earlier than Y6,
+  # you need to set the piff_run above too
+  psf_type: piff
+  psf_kwargs:
+    g:
+      GI_COLOR: 1.3
+    r:
+      GI_COLOR: 1.3
+    i:
+      GI_COLOR: 1.3
+    z:
+      IZ_COLOR: 0.34
+  piff_cuts:
+    max_fwhm_cen: 3.6
+    min_nstar: 30
+    max_exp_T_mean_fac: null
+    max_ccd_T_std_fac: null
+  mask_piff_failure:
+    grid_size: 128
+    max_abs_T_diff: 0.15
+
+  # which SE WCS to use - one of piff, pixmappy or image
+  wcs_type: pixmappy
+  wcs_color: 1.3
+
+  ignored_ccds:
+    - 31
+
+  reject_outliers: False
+  symmetrize_masking: True
+  copy_masked_edges: True
+  max_masked_fraction: 0.1
+  edge_buffer: 48
+
+  # Y6 already deals with tapebump in a sensible way
+  mask_tape_bumps: False
+
+  # DES Y6 bit mask flags
+  # "BPM":          1,  #/* set in bpm (hot/dead pixel/column)        */
+  # "SATURATE":     2,  #/* saturated pixel                           */
+  # "INTERP":       4,  #/* interpolated pixel                        */
+  # "BADAMP":       8,  #/* Data from non-functional amplifier        */
+  # "CRAY":        16,  #/* cosmic ray pixel                          */
+  # "STAR":        32,  #/* bright star pixel                         */
+  # "TRAIL":       64,  #/* bleed trail pixel                         */
+  # "EDGEBLEED":  128,  #/* edge bleed pixel                          */
+  # "SSXTALK":    256,  #/* pixel potentially effected by xtalk from  */
+  #                     #/*       a super-saturated source            */
+  # "EDGE":       512,  #/* pixel flag to exclude CCD glowing edges   */
+  # "STREAK":    1024,  #/* pixel associated with streak from a       */
+  #                     #/*       satellite, meteor, ufo...           */
+  # "SUSPECT":   2048,  #/* nominally useful pixel but not perfect    */
+  # "FIXED":     4096,  # bad coilumn that DESDM reliably fixes       */
+  # "NEAREDGE":  8192,  #/* marks 25 bad columns neat the edge        */
+  # "TAPEBUMP": 16384,  #/* tape bumps                                */
+
+  spline_interp_flags:
+    - 1     # BPM
+    - 2     # SATURATE
+    - 4     # INTERP. Already interpolated; is this ever set?
+    - 16    # CRAY
+    - 64    # TRAIL
+    - 128   # EDGEBLEED
+    - 256   # SSXTALK
+    - 512   # EDGE
+    - 1024  # STREAK
+
+  noise_interp_flags:
+    - 0
+
+  # make the judgment call that it is better to use the somewhat
+  # suspect TAPEBUMP/SUSPECT areas than interp, because they are
+  # fairly large
+  # star areas are ignored for now - GAIA masks will handle them or star-gal sep
+  #  - 32    # STAR
+  #  - 2048  # SUSPECT
+  #  - 4096  # FIXED by DESDM reliably
+  #  - 8192  # NEAREDGE 25 bad columns on each edge, removed anyways due to 48 pixel boundry
+  #  - 16384 # TAPEBUMP
+
+  bad_image_flags:
+    # data from non-functional amplifiers is ignored
+    - 8     # BADAMP
+
+  gaia_star_masks:
+    poly_coeffs: [1.36055007e-03, -1.55098040e-01,  3.46641671e+00]
+    max_g_mag: 18.0
+    symmetrize: False
+    # interp:
+    #   fill_isolated_with_noise: False
+    #   iso_buff: 1
+    apodize:
+      ap_rad: 1
+    mask_expand_rad: 16


### PR DESCRIPTION
This PR has the new config with the updated g-i color. 

Here is the diff from the old one:

```diff
--- config_files/des-pizza-slices-y6-v12.yaml	2022-01-15 13:09:27.000000000 -0600
+++ config_files/des-pizza-slices-y6-v13.yaml	2022-03-25 16:00:40.000000000 -0500
@@ -41,11 +41,11 @@
   psf_type: piff
   psf_kwargs:
     g:
-      GI_COLOR: 0.61
+      GI_COLOR: 1.3
     r:
-      GI_COLOR: 0.61
+      GI_COLOR: 1.3
     i:
-      GI_COLOR: 0.61
+      GI_COLOR: 1.3
     z:
       IZ_COLOR: 0.34
   piff_cuts:
@@ -59,7 +59,7 @@
 
   # which SE WCS to use - one of piff, pixmappy or image
   wcs_type: pixmappy
-  wcs_color: 0.61
+  wcs_color: 1.3
 
   ignored_ccds:
     - 31

```